### PR TITLE
qt-cleanup

### DIFF
--- a/Configuration.ui
+++ b/Configuration.ui
@@ -3363,7 +3363,7 @@ Right click for insert and delete options.</string>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_15">
+            <spacer name="horizontalSpacer_15_otp">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -3529,17 +3529,17 @@ Right click for insert and delete options.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+    <widget class="QWidget" name="wsjtz_tab">
       <attribute name="title">
        <string>WSJT-Z</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_18">
+    <layout class="QGridLayout" name="gridLayout_wsjtz">
        <item row="3" column="1" rowspan="2" colspan="2">
         <widget class="QGroupBox" name="groupBox_13">
          <property name="title">
           <string>Ignore List</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_17">
+         <layout class="QGridLayout" name="gridLayout_ignore_list">
           <item row="2" column="1">
            <widget class="QSpinBox" name="sb_ignoreListReset">
             <property name="suffix">
@@ -3594,7 +3594,7 @@ Right click for insert and delete options.</string>
          <property name="checkable">
           <bool>true</bool>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_25">
+         <layout class="QHBoxLayout" name="horizontalLayout_autoTXFreq">
           <item>
            <widget class="QRadioButton" name="rb_autoFreqWide">
             <property name="text">
@@ -3617,7 +3617,7 @@ Right click for insert and delete options.</string>
          <property name="currentIndex">
           <number>0</number>
          </property>
-         <widget class="QWidget" name="tab">
+         <widget class="QWidget" name="wsjtz_rx_windows_tab">
           <attribute name="title">
            <string>RX  Windows</string>
           </attribute>
@@ -3846,14 +3846,14 @@ Right click for insert and delete options.</string>
         </spacer>
        </item>
        <item row="0" column="0" colspan="3">
-        <widget class="QGroupBox" name="groupBox_8">
+        <widget class="QGroupBox" name="groupBox_qrzcom">
          <property name="title">
           <string>QRZ.COM</string>
          </property>
          <property name="flat">
           <bool>false</bool>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_23">
+         <layout class="QHBoxLayout" name="horizontalLayout_qrzcom">
           <item>
            <widget class="QLabel" name="label_18">
             <property name="text">
@@ -3934,7 +3934,7 @@ Right click for insert and delete options.</string>
          <property name="title">
           <string>Debug</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_24">
+         <layout class="QHBoxLayout" name="horizontalLayout_debug">
           <item>
            <widget class="QRadioButton" name="rb_dbg_Screen">
             <property name="text">

--- a/widgets/pskreporterwidget.cpp
+++ b/widgets/pskreporterwidget.cpp
@@ -12,7 +12,6 @@
 #include <QXmlStreamReader>
 #include "logbook/AD1CCty.hpp"
 #include <QString>
-#include <QtConcurrent/QtConcurrent>
 
 PSKReporterWidget::PSKReporterWidget(QWidget *parent, Configuration * cfg, LogBook * log) :
     QWidget(parent),
@@ -64,7 +63,7 @@ void PSKReporterWidget::responseHandler(QNetworkReply * reply) {
     disconnect(networkManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(responseHandler(QNetworkReply*)));
     if(reply->error() == QNetworkReply::NoError) {
        QString data = (QString)reply->readAll();
-       if (data.length()) QFuture<void> future = QtConcurrent::run (this, &PSKReporterWidget::updateTable, data);
+       if (data.length()) updateTable(data);
 
     } else {
         ui->pskTable->setRowCount(0);


### PR DESCRIPTION
Clear QSocketNotifier: Can only be used with threads started with QThread the UI table was being updated from a QtConcurrent worker thread. That is unsafe for QWidget objects and can cause hard-to-explain Qt thread warnings.