### PR TITLE
fix QRM issue

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -5714,14 +5714,19 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
 
 	// Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
     if (m_auto
-        && (m_QSOProgress==REPLYING  or (!ui->tx1->isEnabled () and m_QSOProgress==REPORT))
+        && (m_QSOProgress==CALLING
+            || m_QSOProgress==REPLYING
+            || (!ui->tx1->isEnabled () and m_QSOProgress==REPORT))
         && (SpecOp::HOUND != m_specOp) && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //
         && message_words.at (2) != "DE"
         && !message_words.at (2).contains (QRegularExpression {"(^(CQ|QRZ))|" + m_baseCall})
-        // Selected DX station is transmitting to another caller, not to us.
-        && message_words.at (2).contains (Radio::base_callsign (ui->dxCallEntry->text ()))
-        && !message_words.at (3).contains (m_baseCall)
-        && !message_words.at (3).contains (m_config.my_callsign ())) {
+        // Selected DX station is in QSO with someone else (in either call position).
+        && ((message_words.at (2).contains (Radio::base_callsign (ui->dxCallEntry->text ()))
+             && !message_words.at (3).contains (m_baseCall)
+             && !message_words.at (3).contains (m_config.my_callsign ()))
+            || (message_words.at (3).contains (Radio::base_callsign (ui->dxCallEntry->text ()))
+                && !message_words.at (2).contains (m_baseCall)
+                && !message_words.at (2).contains (m_config.my_callsign ())))) {
       // auto stop to avoid accidental QRM
         // Z
         if (m_zdebug) log("Automatic TX halt");


### PR DESCRIPTION
Before: halt logic only ran in REPLYING/REPORT
After: halt logic runs in CALLING/REPLYING/REPORT

It now halts when selected DX appears in either callsign position of a directed message and the other callsign is not own

this was broken I suspect in the patch here https://github.com/SpudGunMan/wsjt-z/commit/c73b40470ea3916d2e28a0bd63e4edb398bf5f82

it could be reverted to pushed your call