### PR TITLE
73 to CQ without any Auto CQ

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -14364,7 +14364,8 @@ void MainWindow::ZProcess ()
     if (m_QSOProgress == CALLING) {
         if (m_zdebug) log("ZProcess: m_QSOProgress = CALLING");
 
-        if (ui->cbAutoCall->isChecked() || ui->cbAutoCQ->isChecked()) {
+      // Only run auto mode countdown/switch logic while Auto is active.
+      if (ui->autoButton->isChecked() && (ui->cbAutoCall->isChecked() || ui->cbAutoCQ->isChecked())) {
 
                 if (ui->cbAutoCall->isChecked()) {
                     int l = ui->le_autoCallLeft->text().toInt();


### PR DESCRIPTION
code could process CALLING state transitions after a 73 and still run mode-switch logic even with Auto not active, which could set Auto CQ unexpectedly. Now that path is blocked unless Auto is actively enabled.

**currently testing