### PR TITLE
73toCQ

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -1834,6 +1834,7 @@ void Configuration::impl::initialize_models ()
   ui_->cb_clearRx->setChecked(clearRx_);
   ui_->cb_freezeBA->setChecked(freezeBA_);
   ui_->cb_removeExtra->setChecked(removeExtra_);
+  ui_->cb_postSignoffWatchdog->setChecked(settings_->value("postSignoffWatchdog", true).toBool());
   ui_->sb_ignoreListReset->setValue(ignoreListReset_);
   ui_->le_separatorColor->setText(separatorColor_);
   ui_->le_alertCmdLine->setText(alertCmdLine_);
@@ -2288,6 +2289,7 @@ void Configuration::impl::write_settings ()
   settings_->setValue("colourAll", colourAll_);
   settings_->setValue("autoCQfiltering", autoCQfiltering_);
   settings_->setValue("rxTotxFreq", rxTotxFreq_);
+  settings_->setValue("postSignoffWatchdog", ui_->cb_postSignoffWatchdog->isChecked());
   settings_->setValue("udpFiltering", udpFiltering_);
   settings_->setValue("highlightDX", highlightDX_);
   settings_->setValue("dbgScreen", dbgScreen_);

--- a/Configuration.ui
+++ b/Configuration.ui
@@ -3768,6 +3768,16 @@ Right click for insert and delete options.</string>
              </property>
             </widget>
            </item>
+           <item row="4" column="1">
+            <widget class="QCheckBox" name="cb_postSignoffWatchdog">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, late replies after a completed QSO are preferred over starting a new QSO and will not reset the TX watchdog. This helps the closing exchange continue with TX4/5 after a 73.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Leave WD active after post-signoff reply</string>
+             </property>
+            </widget>
+           </item>
            <item row="1" column="0">
             <widget class="QCheckBox" name="cb_disableWriteFoxQSO">
              <property name="toolTip">

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -7299,6 +7299,24 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
           setTxMsg(3);
           m_QSOProgress=ROGER_REPORT;
         }
+      } else if (message_words.size () > 5
+                 && "R" == message_words.at (4)
+                 && message_words.at (5).contains (grid_regexp)
+                 && SpecOp::EU_VHF != m_specOp) {
+        // "MYCALL DXCALL R GRID" — DX station confirmed our exchange and sent their grid.
+        // In VHF contest modes (NA_VHF/WW_DIGI/ARRL_DIGI/Q65_PILEUP) the protocol
+        // requires us to reply with RRR before logging, so just advance to ROGERS.
+        // In all other modes queue Tx4 (RRR) and keep the QSO open so the normal
+        // closing path (RRR/RR73/73) can finish the contact.
+        bool vhf_contest = (SpecOp::NA_VHF == m_specOp || SpecOp::WW_DIGI == m_specOp
+                            || SpecOp::ARRL_DIGI == m_specOp || SpecOp::Q65_PILEUP == m_specOp);
+        setTxMsg (4);
+        m_QSOProgress = ROGERS;
+        if (!vhf_contest) {
+          // Do not log immediately here; keep the QSO open so TX4 (RRR)
+          // can actually be sent and the normal closing path (RRR/RR73/73)
+          // can complete the QSO.
+        }
       } else {  // no grid on end of msg
         auto const& word_3 = message_words.at (4);
         auto word_3_as_number = word_3.toInt ();
@@ -7354,8 +7372,8 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
                 m_ntx=6;
                 ui->txrb6->setChecked(true);
               }
-            else if ((m_QSOProgress > CALLING && m_QSOProgress < ROGERS)
-                     || "RRR" == word_3)
+            else if (m_QSOProgress < ROGERS
+                     && (m_QSOProgress > CALLING || "RRR" == word_3))
               {
                 m_ntx=5;
                 ui->txrb5->setChecked(true);

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -7327,8 +7327,8 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
                 else {
                   cease_auto_Tx_after_QSO ();
                 }
-                m_ntx=6;
-                ui->txrb6->setChecked(true);
+                m_ntx=5;
+                ui->txrb5->setChecked(true);
               }
             else
               {

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -281,6 +281,21 @@ namespace
           || (type == 6 && !msg_parts.filter ("73").isEmpty ()));
   }
 
+  bool token_matches_call (QString const& token, QString const& call)
+  {
+    auto const& base_call = Radio::base_callsign (call);
+    return !token.isEmpty ()
+      && (token == call
+          || token == base_call
+          || token.endsWith ("/" + base_call)
+          || token.startsWith (base_call + "/"));
+  }
+
+  bool composite_rr73 (QStringList const& words)
+  {
+    return words.size () > 1 && words.at (1) == "RR73;";
+  }
+
   int ms_minute_error ()
   {
     auto const& now = QDateTime::currentDateTimeUtc ();
@@ -5669,6 +5684,12 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
   auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
   auto msg_no_hash = message.clean_string();
   msg_no_hash = msg_no_hash.mid(22).remove("<").remove(">");
+  auto const& raw_words = msg_no_hash.split(" ",SkipEmptyParts);
+  bool composite_rr73_detected = composite_rr73 (raw_words);
+  bool composite_rr73_for_me = composite_rr73_detected
+    && (token_matches_call (raw_words.value (0), m_config.my_callsign ())
+        || token_matches_call (raw_words.value (0), m_baseCall));
+  bool terminal_signoff = is_73 || composite_rr73_detected;
 
   if (m_zdebug) log("msg_no_hash: " + msg_no_hash);
   if (m_zdebug) log("isStandardMessage: " +  QString::number(message.isStandardMessage()));
@@ -5689,7 +5710,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
                || message_words.contains ("DE")))
           || (!message.isStandardMessage () && m_mode != "MSK144")); // free text 73/RR73 except for MSK
 
-    auto const& w = msg_no_hash.split(" ",SkipEmptyParts);
+    auto const& w = raw_words;
     QString w2;
     int nrpt=0;
     if (w.size () > 2)
@@ -5716,6 +5737,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
     if (m_auto
         && (m_QSOProgress==REPLYING  or (!ui->tx1->isEnabled () and m_QSOProgress==REPORT))
         && (SpecOp::HOUND != m_specOp) && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //
+      && !composite_rr73_for_me
         && message_words.at (2) != "DE"
         && !message_words.at (2).contains (QRegularExpression {"(^(CQ|QRZ))|" + m_baseCall})
         // Selected DX station is transmitting to another caller, not to us.
@@ -5736,7 +5758,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
                          // being called and not already in a QSO
                          && (message_words.at(3).contains(Radio::base_callsign(ui->dxCallEntry->text()))
                              or bEU_VHF))
-                        || message_words.at(1) == m_baseCall // <de-call> RR73; ...
+                      || composite_rr73_for_me // <de-call> RR73; ...
                         // type 2 compound replies
                         || (within_tolerance &&
                             (acceptable_73 ||
@@ -5760,7 +5782,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
                && message_words.at (2).contains (m_baseCall)
                && (ui->cbAutoCQ->isChecked() || ui->cbAutoCall->isChecked())
                && m_QSOProgress == CALLING
-               && !(message_words.filter (QRegularExpression {"^(73|RR73|RRR)$"}).size())
+               && !terminal_signoff
                && (m_config.processTailenders() || m_lastCall == hiscall)
                && (!m_transmitting)
                )
@@ -7103,7 +7125,12 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
     }
   }
 
-  bool is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size ();
+  bool composite_rr73_detected = composite_rr73 (w);
+  bool composite_rr73_for_me = composite_rr73_detected
+    && (token_matches_call (w.value (0), m_config.my_callsign ())
+        || token_matches_call (w.value (0), m_baseCall));
+  bool is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size ()
+    || composite_rr73_detected;
   if (!is_73 and !message.isStandardMessage() and !message.clean_string ().contains("<")) {
     qDebug () << "Not processing message - hiscall:" << hiscall << "hisgrid:" << hisgrid
               << message.clean_string () << message.isStandardMessage();
@@ -7275,11 +7302,13 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
       } else {  // no grid on end of msg
         auto const& word_3 = message_words.at (4);
         auto word_3_as_number = word_3.toInt ();
+        bool received_73 = (word_3_as_number == 73);
+        bool received_rr73 = ("RR73" == word_3);
         if (("RRR" == word_3
-             || (word_3_as_number == 73 && ROGERS == m_QSOProgress)
-             || "RR73" == word_3
+             || (received_73 && m_QSOProgress >= ROGERS)
+             || received_rr73
              || ("R" == word_3 && m_QSOProgress != REPORT))) {
-          if((m_mode=="FT4" or m_mode=="FT2") and "RR73" == word_3) m_dateTimeRcvdRR73=QDateTime::currentDateTimeUtc();
+          if((m_mode=="FT4" or m_mode=="FT2") and received_rr73) m_dateTimeRcvdRR73=QDateTime::currentDateTimeUtc();
           m_bTUmsg=false;
           m_nextCall="";   //### Temporary: disable use of "TU;" message
           if(SpecOp::RTTY == m_specOp and m_nextCall!="") {
@@ -7313,8 +7342,20 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
                 m_ntx=4;
                 ui->txrb4->setChecked(true);
               }
+            else if (received_rr73
+                     || (received_73 && m_QSOProgress >= ROGERS))
+              {
+                if (m_config.prompt_to_log() || m_config.autoLog()) {
+                  logQSOTimer.start(0);
+                }
+                else {
+                  cease_auto_Tx_after_QSO ();
+                }
+                m_ntx=6;
+                ui->txrb6->setChecked(true);
+              }
             else if ((m_QSOProgress > CALLING && m_QSOProgress < ROGERS)
-                     || word_3.contains (QRegularExpression {"^RR(?:R|73)$"}))
+                     || "RRR" == word_3)
               {
                 m_ntx=5;
                 ui->txrb5->setChecked(true);
@@ -7393,8 +7434,9 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
           }
       }
     }
-    else if (5 == message_words.size ()
-             && m_baseCall == message_words.at (1)) {
+    else if (composite_rr73_for_me
+             || (5 == message_words.size ()
+                 && m_baseCall == message_words.at (1))) {
       // dual Fox style message, possibly from MSHV
       if (m_config.prompt_to_log() || m_config.autoLog()) {
         logQSOTimer.start(0);

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -7252,7 +7252,16 @@ void MainWindow::processMessage (DecodedText const& message, Qt::KeyboardModifie
       // Without this, WD expiring during a long CQ campaign blocks the
       // very next TX cycle, so the reply never goes out (worst on FT2
       // where TR period is 2s and many CQ cycles fit inside one minute).
-      tx_watchdog (false);
+      bool postSignoffResponse = QSettings().value("postSignoffWatchdog", true).toBool()
+          && (m_QSOProgress == SIGNOFF || m_sentFirst73)
+          && message_words.size() > 4
+          && message_words.at(4).startsWith('R')
+          && (message_words.at(2).contains(m_baseCall) || "DE" == message_words.at(2));
+      if (postSignoffResponse) {
+          if (m_zdebug) log("post-signoff response received, leaving watchdog active");
+      } else {
+          tx_watchdog (false);
+      }
       if(message_words.at(4).contains(grid_regexp) and SpecOp::EU_VHF!=m_specOp) {
         if((SpecOp::NA_VHF==m_specOp or SpecOp::WW_DIGI==m_specOp or
             SpecOp::ARRL_DIGI==m_specOp or SpecOp::Q65_PILEUP==m_specOp)


### PR DESCRIPTION
In mainwindow.cpp:7322, the ROGERS-state branch after receiving RRR/RR73/73 now selects Tx5 (73) instead of Tx6 (CQ). That branch was explicitly switching to CQ message flow when a signoff arrived, which could make the app call CQ automatically. Keeping it on Tx5 prevents that automatic CQ transition on received 73.