### PR TITLE
patch-wd-logic and QRM problem

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -826,9 +826,9 @@ private:
   bool autoFreqWide_;
   bool wdResetAnywhere_;
   int padding_;
-  int wd_FT8_;
-  int wd_FT4_;
-  int wd_FT2_;
+  double wd_FT8_;
+  double wd_FT4_;
+  double wd_FT2_;
   bool wd_Timer_;
   bool processTailenders_;
   QString permIgnoreList_;
@@ -980,9 +980,9 @@ bool Configuration::autoFreqNarrow() const {return m_->autoFreqNarrow_;}
 bool Configuration::autoFreqWide() const {return m_->autoFreqWide_;}
 bool Configuration::wdResetAnywhere() const {return m_->wdResetAnywhere_;}
 int Configuration::padding() const {return m_->padding_;}
-int Configuration::wd_FT8() const {return m_->wd_FT8_;}
-int Configuration::wd_FT4() const {return m_->wd_FT4_;}
-int Configuration::wd_FT2() const {return m_->wd_FT2_;}
+double Configuration::wd_FT8() const {return m_->wd_FT8_;}
+double Configuration::wd_FT4() const {return m_->wd_FT4_;}
+double Configuration::wd_FT2() const {return m_->wd_FT2_;}
 bool Configuration::wd_Timer() const {return m_->wd_Timer_;}
 bool Configuration::processTailenders() const {return m_->processTailenders_;}
 QString Configuration::permIgnoreList() const {return m_->permIgnoreList_;}
@@ -2102,9 +2102,9 @@ void Configuration::impl::read_settings ()
   dbgFile_ = settings_->value("dbgFile").toBool();
   wdResetAnywhere_ = settings_->value("wdResetAnywhere", true).toBool();
   padding_ = settings_->value("padding",42).toInt ();
-  wd_FT8_ = settings_->value("wd_FT8",2).toInt ();
-  wd_FT4_ = settings_->value("wd_FT4",1).toInt ();
-  wd_FT2_ = settings_->value("wd_FT2",1).toInt ();
+  wd_FT8_ = settings_->value("wd_FT8",2.0).toDouble ();
+  wd_FT4_ = settings_->value("wd_FT4",1.0).toDouble ();
+  wd_FT2_ = settings_->value("wd_FT2",1.0).toDouble ();
   wd_Timer_ = settings_->value("wd_Timer", false).toBool();
   processTailenders_ = settings_->value("processTailenders", false).toBool();
   permIgnoreList_ = settings_->value("permIgnoreList").toString();

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -224,9 +224,9 @@ public:
   bool autoFreqWide() const;
   bool autoFreqNarrow() const;
   bool wdResetAnywhere() const;
-  int wd_FT8() const ;
-  int wd_FT4() const;
-  int wd_FT2() const;
+  double wd_FT8() const ;
+  double wd_FT4() const;
+  double wd_FT2() const;
   bool wd_Timer() const;
   bool processTailenders() const;
   QString permIgnoreList() const;

--- a/Configuration.ui
+++ b/Configuration.ui
@@ -3904,7 +3904,14 @@ Right click for insert and delete options.</string>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QSpinBox" name="sb_WD_FT8"/>
+           <widget class="QDoubleSpinBox" name="sb_WD_FT8">
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="singleStep">
+             <double>0.250000000000000</double>
+            </property>
+           </widget>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_16">
@@ -3914,7 +3921,14 @@ Right click for insert and delete options.</string>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QSpinBox" name="sb_WD_FT4"/>
+           <widget class="QDoubleSpinBox" name="sb_WD_FT4">
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="singleStep">
+             <double>0.250000000000000</double>
+            </property>
+           </widget>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_WD_FT2">
@@ -3924,7 +3938,14 @@ Right click for insert and delete options.</string>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QSpinBox" name="sb_WD_FT2"/>
+           <widget class="QDoubleSpinBox" name="sb_WD_FT2">
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="singleStep">
+             <double>0.250000000000000</double>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -1377,11 +1377,12 @@ void MainWindow::on_the_minute ()
         }
     }
   // Z
-  if (watchdog () && m_mode!="WSPR" && m_mode!="FST4W") {
-    // Keep AutoCQ's existing CALLING pause behavior, but let AutoCall obey WD
-    // so it can time out as expected when no QSO starts.
-    bool const pause_for_autocq = ui->cbAutoCQ->isChecked ()
-                                  && m_QSOProgress == CALLING;
+  auto const wd_limit = watchdog ();
+  bool const wd_enabled = wd_limit > 0.0 && m_mode!="WSPR" && m_mode!="FST4W";
+  // Keep AutoCQ's existing CALLING pause behavior, but let AutoCall obey WD.
+  bool const pause_for_autocq = ui->cbAutoCQ->isChecked ()
+                                && m_QSOProgress == CALLING;
+  if (wd_enabled) {
     auto const now_utc = QDateTime::currentDateTimeUtc ();
     if (!m_watchdogAnchorUtc.isValid ()) {
       m_watchdogAnchorUtc = now_utc;
@@ -1390,12 +1391,12 @@ void MainWindow::on_the_minute ()
       // Freeze WD accrual while AutoCQ is parked in CALLING state.
       m_watchdogAnchorUtc = now_utc;
     } else {
-      int const elapsed_seconds = m_watchdogAnchorUtc.secsTo (now_utc);
-      if (elapsed_seconds >= 60 && m_idleMinutes < watchdog ()) {
-        int add_minutes = elapsed_seconds / 60;
-        m_idleMinutes = qMin (watchdog (), m_idleMinutes + add_minutes);
-        m_watchdogAnchorUtc = m_watchdogAnchorUtc.addSecs (add_minutes * 60);
+      auto elapsed_seconds = m_watchdogAnchorUtc.secsTo (now_utc);
+      if (elapsed_seconds < 0) {
+        m_watchdogAnchorUtc = now_utc;
+        elapsed_seconds = 0;
       }
+      m_idleMinutes = qMin (wd_limit, elapsed_seconds / 60.0);
     }
     update_watchdog_label ();
   } else {
@@ -6063,8 +6064,26 @@ void MainWindow::guiUpdate()
       m_foxWarningDialFreq0 = 0.0;
     }
     // Z
-    if (watchdog() && m_mode!="WSPR" && m_mode!="FST4W"
-        && m_idleMinutes >= watchdog ()) {
+    auto const wd_limit = watchdog ();
+    bool const wd_enabled = wd_limit > 0.0 && m_mode!="WSPR" && m_mode!="FST4W";
+    bool const wd_paused = ui->cbAutoCQ->isChecked() && m_QSOProgress == CALLING;
+    auto const now_utc = QDateTime::currentDateTimeUtc ();
+    if (wd_enabled && !wd_paused) {
+      if (!m_watchdogAnchorUtc.isValid ()) {
+        m_watchdogAnchorUtc = now_utc;
+      }
+      auto elapsed_seconds = m_watchdogAnchorUtc.secsTo (now_utc);
+      if (elapsed_seconds < 0) {
+        m_watchdogAnchorUtc = now_utc;
+        elapsed_seconds = 0;
+      }
+      m_idleMinutes = qMin (wd_limit, elapsed_seconds / 60.0);
+    } else {
+      m_idleMinutes = 0.0;
+      m_watchdogAnchorUtc = now_utc;
+    }
+    update_watchdog_label ();
+    if (wd_enabled && m_idleMinutes >= wd_limit) {
       tx_watchdog (true);       // disable transmit
     }
 
@@ -11624,9 +11643,18 @@ void MainWindow::tx_watchdog (bool triggered)
 
 void MainWindow::update_watchdog_label ()
 {
-  if (watchdog () && m_mode!="WSPR" && m_mode!="FST4W")
+  auto const wd_limit = watchdog ();
+  if (wd_limit > 0.0 && m_mode!="WSPR" && m_mode!="FST4W")
     {
-      watchdog_label.setText (tr ("WD:%1m").arg (watchdog () - m_idleMinutes));
+      auto remaining_minutes = qMax (0.0, wd_limit - m_idleMinutes);
+      if (remaining_minutes < 1.0)
+        {
+          watchdog_label.setText (tr ("WD:%1s").arg (int (remaining_minutes * 60.0 + 0.5)));
+        }
+      else
+        {
+          watchdog_label.setText (tr ("WD:%1m").arg (QString::number (remaining_minutes, 'f', 2)));
+        }
       watchdog_label.setVisible (true);
     }
   else
@@ -14553,13 +14581,13 @@ void MainWindow::resetAutoSwitch() {
   update_mode_switch_status_label ();
 }
 
-int MainWindow::watchdog() {
+double MainWindow::watchdog() {
     if (m_config.wd_Timer()) {
         if (m_mode == "FT8") return m_config.wd_FT8();
         if (m_mode == "FT2") return m_config.wd_FT2();
         if (m_mode == "FT4") return m_config.wd_FT4();
     }
-    return m_config.watchdog();
+  return static_cast<double> (m_config.watchdog());
 }
 
 void MainWindow::on_actionDark_mode_triggered() {

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -11550,11 +11550,11 @@ void MainWindow::tx_watchdog (bool triggered)
           bool const same_target = !candidate_base.isEmpty ()
                                    && !his_base.isEmpty ()
                                    && candidate_base == his_base;
+          bool const target_uncertain = his_base.isEmpty () || candidate_base.isEmpty ();
           bool const already_ignored = m_ignoredStationsCache.contains (ignore_candidate)
                                        || m_ignoredStationsCache.contains (candidate_base);
 
-          if (m_QSOProgress == CALLING
-              && same_target
+          if ((same_target || target_uncertain)
               && !ignore_candidate.isEmpty ()
               && !already_ignored)
             {
@@ -11565,7 +11565,7 @@ void MainWindow::tx_watchdog (bool triggered)
             {
               log("TXWatchdog: Skip ignore-list add (candidate='" + ignore_candidate
                   + "', same_target=" + QString::number (same_target)
-                  + ", calling_state=" + QString::number (m_QSOProgress == CALLING)
+                  + ", target_uncertain=" + QString::number (target_uncertain)
                   + ", already_ignored=" + QString::number (already_ignored) + ")");
             }
         }
@@ -13116,7 +13116,17 @@ void MainWindow::on_cbAutoCQ_toggled(bool b)
 }
 
 void MainWindow::on_btn_addToIgnore_clicked( ) {
-    ui->pte_IgnoredStations->appendPlainText(m_hisCall);
+    auto const candidate = ui->dxCallEntry->text().trimmed().isEmpty ()
+                           ? m_hisCall.trimmed ()
+                           : ui->dxCallEntry->text().trimmed ();
+    if (candidate.isEmpty ()) return;
+
+    if (!m_filterCacheValid) rebuildFilterCache();
+    if (!m_ignoredStationsCache.contains (candidate)
+        && !m_ignoredStationsCache.contains (Radio::base_callsign (candidate)))
+      {
+        ui->pte_IgnoredStations->appendPlainText(candidate);
+      }
 }
 
 void MainWindow::on_btn_clearIgnore_clicked( ) {
@@ -13611,7 +13621,16 @@ void MainWindow::on_actionIgnore_station_triggered() {
     DecodedText message {cursor.selectedText().trimmed().remove("TU; ")};
     message.deCallAndGrid (/*out*/ dxCall, dxGrid);
 
-    ui->pte_IgnoredStations->appendPlainText(dxCall);
+    dxCall = dxCall.trimmed();
+    if (!dxCall.isEmpty ())
+      {
+        if (!m_filterCacheValid) rebuildFilterCache();
+        if (!m_ignoredStationsCache.contains (dxCall)
+            && !m_ignoredStationsCache.contains (Radio::base_callsign (dxCall)))
+          {
+            ui->pte_IgnoredStations->appendPlainText(dxCall);
+          }
+      }
     cursor.movePosition(QTextCursor::End); // move/modify/etc.
 
     if (ui->decodedTextBrowser->hasFocus()) {

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -11646,14 +11646,24 @@ void MainWindow::update_watchdog_label ()
   auto const wd_limit = watchdog ();
   if (wd_limit > 0.0 && m_mode!="WSPR" && m_mode!="FST4W")
     {
-      auto remaining_minutes = qMax (0.0, wd_limit - m_idleMinutes);
-      if (remaining_minutes < 1.0)
+      auto const remaining_minutes = qMax (0.0, wd_limit - m_idleMinutes);
+      auto const remaining_seconds = int (remaining_minutes * 60.0 + 0.5);
+      if (remaining_seconds < 60)
         {
-          watchdog_label.setText (tr ("WD:%1s").arg (int (remaining_minutes * 60.0 + 0.5)));
+          watchdog_label.setText (tr ("WD:%1s").arg (remaining_seconds));
         }
       else
         {
-          watchdog_label.setText (tr ("WD:%1m").arg (QString::number (remaining_minutes, 'f', 2)));
+          auto const minutes = remaining_seconds / 60;
+          auto const seconds = remaining_seconds % 60;
+          if (seconds == 0)
+            {
+              watchdog_label.setText (tr ("WD:%1m").arg (minutes));
+            }
+          else
+            {
+              watchdog_label.setText (tr ("WD:%1m%2s").arg (minutes).arg (seconds, 2, 10, QChar ('0')));
+            }
         }
       watchdog_label.setVisible (true);
     }

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -11616,7 +11616,10 @@ void MainWindow::tx_watchdog (bool triggered)
         }
 
       if (ui->cbAutoCQ->isChecked()) {
+                  bool const old_block = ui->txrb6->blockSignals(true);
                   ui->txrb6->setChecked (true);
+                  ui->txrb6->blockSignals(old_block);
+                  auto_tx_mode(true);
                   m_idleMinutes = 0;
                   m_watchdogAnchorUtc = QDateTime::currentDateTimeUtc ();
                   update_watchdog_label ();

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -473,6 +473,7 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
   m_tx_when_ready {false},
   m_transmitting {false},
   m_tune {false},
+  m_autoCQWatchdogPending {false},
   m_tx_watchdog {false},
   m_block_pwr_tooltip {false},
   m_PwrBandSetOK {true},
@@ -6084,7 +6085,16 @@ void MainWindow::guiUpdate()
     }
     update_watchdog_label ();
     if (wd_enabled && m_idleMinutes >= wd_limit) {
-      tx_watchdog (true);       // disable transmit
+      if (ui->cbAutoCQ->isChecked()) {
+        if (m_bTxTime) {
+          m_autoCQWatchdogPending = false;
+          tx_watchdog (true);       // disable transmit
+        } else if (!m_autoCQWatchdogPending) {
+          m_autoCQWatchdogPending = true;
+        }
+      } else {
+        tx_watchdog (true);       // disable transmit
+      }
     }
 
     double fTR=float((ms%int(1000.0*m_TRperiod)))/int(1000.0*m_TRperiod);
@@ -11619,6 +11629,9 @@ void MainWindow::tx_watchdog (bool triggered)
                   bool const old_block = ui->txrb6->blockSignals(true);
                   ui->txrb6->setChecked (true);
                   ui->txrb6->blockSignals(old_block);
+                  m_ntx = 6;
+                  if (ui->txrb6->text().contains (QRegularExpression {"^(CQ|QRZ) "}))
+                    set_dateTimeQSO(-1);
                   auto_tx_mode(true);
                   m_idleMinutes = 0;
                   m_watchdogAnchorUtc = QDateTime::currentDateTimeUtc ();
@@ -11637,6 +11650,7 @@ void MainWindow::tx_watchdog (bool triggered)
   else
     {
       if (m_zdebug) log("TXWatchdog: FALSE");
+      m_autoCQWatchdogPending = false;
       m_idleMinutes = 0;
       m_watchdogAnchorUtc = QDateTime::currentDateTimeUtc ();
       update_watchdog_label ();

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -1380,25 +1380,17 @@ void MainWindow::on_the_minute ()
   // Z
   auto const wd_limit = watchdog ();
   bool const wd_enabled = wd_limit > 0.0 && m_mode!="WSPR" && m_mode!="FST4W";
-  // Keep AutoCQ's existing CALLING pause behavior, but let AutoCall obey WD.
-  bool const pause_for_autocq = ui->cbAutoCQ->isChecked ()
-                                && m_QSOProgress == CALLING;
   if (wd_enabled) {
     auto const now_utc = QDateTime::currentDateTimeUtc ();
     if (!m_watchdogAnchorUtc.isValid ()) {
       m_watchdogAnchorUtc = now_utc;
     }
-    if (pause_for_autocq) {
-      // Freeze WD accrual while AutoCQ is parked in CALLING state.
+    auto elapsed_seconds = m_watchdogAnchorUtc.secsTo (now_utc);
+    if (elapsed_seconds < 0) {
       m_watchdogAnchorUtc = now_utc;
-    } else {
-      auto elapsed_seconds = m_watchdogAnchorUtc.secsTo (now_utc);
-      if (elapsed_seconds < 0) {
-        m_watchdogAnchorUtc = now_utc;
-        elapsed_seconds = 0;
-      }
-      m_idleMinutes = qMin (wd_limit, elapsed_seconds / 60.0);
+      elapsed_seconds = 0;
     }
+    m_idleMinutes = qMin (wd_limit, elapsed_seconds / 60.0);
     update_watchdog_label ();
   } else {
     // Do not silently reset idle minutes every minute when WD is disabled.
@@ -2759,8 +2751,9 @@ void MainWindow::on_actionFT8WidebandDXCallSearch_toggled(bool checked) { m_FT8W
 
 void MainWindow::on_autoButton_clicked (bool checked)
 {
+  bool const entering_auto = checked && !m_auto;
   // Z
-  if (checked) tx_watchdog(false);
+  if (entering_auto && !m_tx_watchdog) tx_watchdog(false);
   stopWRTimer.stop();             // stop a running Tx3 timer
   m_auto = checked;
   m_maxPoints=-1;
@@ -2793,7 +2786,7 @@ void MainWindow::auto_tx_mode (bool state)
 {
   // Z
   if (m_zdebug) log("AutoTxMode: " + QString::number(state));
-  if (state) tx_watchdog(false);
+  if (state && !m_tx_watchdog && !m_auto) tx_watchdog(false);
 
   if (!state && ui->cbAutoCQ->isChecked()) return;
 
@@ -6067,9 +6060,8 @@ void MainWindow::guiUpdate()
     // Z
     auto const wd_limit = watchdog ();
     bool const wd_enabled = wd_limit > 0.0 && m_mode!="WSPR" && m_mode!="FST4W";
-    bool const wd_paused = ui->cbAutoCQ->isChecked() && m_QSOProgress == CALLING;
     auto const now_utc = QDateTime::currentDateTimeUtc ();
-    if (wd_enabled && !wd_paused) {
+    if (wd_enabled) {
       if (!m_watchdogAnchorUtc.isValid ()) {
         m_watchdogAnchorUtc = now_utc;
       }

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -1376,13 +1376,17 @@ void MainWindow::on_the_minute ()
         }
     }
   // Z
-  if (watchdog () && m_mode!="WSPR" && m_mode!="FST4W"
-      && !((ui->cbAutoCQ->isChecked() || ui->cbAutoCall->isChecked())
-           && m_QSOProgress == CALLING)) {
-    if (m_idleMinutes < watchdog ()) ++m_idleMinutes;
+  if (watchdog () && m_mode!="WSPR" && m_mode!="FST4W") {
+    // Keep AutoCQ's existing CALLING pause behavior, but let AutoCall obey WD
+    // so it can time out as expected when no QSO starts.
+    bool const pause_for_autocq = ui->cbAutoCQ->isChecked ()
+                                  && m_QSOProgress == CALLING;
+    if (!pause_for_autocq && m_idleMinutes < watchdog ()) ++m_idleMinutes;
     update_watchdog_label ();
   } else {
-    tx_watchdog (false);
+    // Do not silently reset idle minutes every minute when WD is disabled.
+    if (m_tx_watchdog) tx_watchdog (false);
+    else update_watchdog_label ();
   }
   update_foxLogWindow_rate(); // update the rate on the window
   if ((!verified && ui->labDXped->isVisible()) or !ui->labDXped->text().contains("Hound"))
@@ -5667,6 +5671,8 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
   if (m_zdebug) log("auto_sequence: " + message.string());
   auto const& message_words = message.messageWords ();
   auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
+  auto const selected_dx_base = Radio::base_callsign (ui->dxCallEntry->text ());
+  bool const have_selected_dx = !selected_dx_base.isEmpty ();
   auto msg_no_hash = message.clean_string();
   msg_no_hash = msg_no_hash.mid(22).remove("<").remove(">");
 
@@ -5711,17 +5717,31 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
     message.deCallAndGrid(/*out*/hiscall,hisgrid);
     bool addressed_to_me = message_words.at (2).contains (m_baseCall);
     bool tailender_ok = (m_config.processTailenders() || m_lastCall == hiscall || !m_bAutoReply);
+    auto normalized_base = [](QString token)
+      {
+        token.remove ('<');
+        token.remove ('>');
+        return Radio::base_callsign (token);
+      };
+    auto const sender_base = normalized_base (message_words.at (2));
+    auto const target_base = normalized_base (message_words.at (3));
+    auto const my_full_base = Radio::base_callsign (m_config.my_callsign ());
+    bool const selected_dx_is_sender = have_selected_dx && sender_base == selected_dx_base;
+    bool const target_is_me = target_base == m_baseCall || target_base == my_full_base;
 
-	// Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
+    // Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
+    bool const auto_qrm_guard_state = m_QSOProgress == CALLING
+                      || m_QSOProgress == REPLYING
+                      || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
     if (m_auto
-        && (m_QSOProgress==REPLYING  or (!ui->tx1->isEnabled () and m_QSOProgress==REPORT))
+        && auto_qrm_guard_state
         && (SpecOp::HOUND != m_specOp) && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //
         && message_words.at (2) != "DE"
         && !message_words.at (2).contains (QRegularExpression {"(^(CQ|QRZ))|" + m_baseCall})
+        && have_selected_dx
         // Selected DX station is transmitting to another caller, not to us.
-        && message_words.at (2).contains (Radio::base_callsign (ui->dxCallEntry->text ()))
-        && !message_words.at (3).contains (m_baseCall)
-        && !message_words.at (3).contains (m_config.my_callsign ())) {
+      && selected_dx_is_sender
+      && !target_is_me) {
       // auto stop to avoid accidental QRM
         // Z
         if (m_zdebug) log("Automatic TX halt");
@@ -6957,9 +6977,6 @@ void MainWindow::doubleClickOnCall2(Qt::KeyboardModifiers modifiers)
 
 void MainWindow::doubleClickOnCall(Qt::KeyboardModifiers modifiers)
 {
-  // Z
-  tx_watchdog(false);
-
   QTextCursor cursor;
   if(m_mode=="FST4W") {
     MessageBox::information_message (this,
@@ -7007,6 +7024,9 @@ void MainWindow::doubleClickOnCall(Qt::KeyboardModifiers modifiers)
     }
     return;
   }
+
+  // Valid call selection starts a fresh WD window.
+  tx_watchdog(false);
   m_bDoubleClicked = true;
   m_hisCall0 = m_hisCall;
   processMessage (message, modifiers);
@@ -11521,7 +11541,34 @@ void MainWindow::tx_watchdog (bool triggered)
       m_bTxTime=false;
       // Z
       if (ui->cbAutoCall->isChecked() && ui->cb_IgnoreAfterWD->isChecked())
-          ui->pte_IgnoredStations->appendPlainText(m_hisCall);
+        {
+          auto const active_call = ui->dxCallEntry->text().trimmed();
+          auto const his_call = m_hisCall.trimmed();
+          auto const ignore_candidate = active_call.isEmpty () ? his_call : active_call;
+          auto const candidate_base = Radio::base_callsign (ignore_candidate);
+          auto const his_base = Radio::base_callsign (his_call);
+          bool const same_target = !candidate_base.isEmpty ()
+                                   && !his_base.isEmpty ()
+                                   && candidate_base == his_base;
+          bool const already_ignored = m_ignoredStationsCache.contains (ignore_candidate)
+                                       || m_ignoredStationsCache.contains (candidate_base);
+
+          if (m_QSOProgress == CALLING
+              && same_target
+              && !ignore_candidate.isEmpty ()
+              && !already_ignored)
+            {
+              ui->pte_IgnoredStations->appendPlainText(ignore_candidate);
+              if (m_zdebug) log("TXWatchdog: Added to ignore list after WD timeout: " + ignore_candidate);
+            }
+          else if (m_zdebug)
+            {
+              log("TXWatchdog: Skip ignore-list add (candidate='" + ignore_candidate
+                  + "', same_target=" + QString::number (same_target)
+                  + ", calling_state=" + QString::number (m_QSOProgress == CALLING)
+                  + ", already_ignored=" + QString::number (already_ignored) + ")");
+            }
+        }
 
       if (ui->cbAutoCQ->isChecked()) {
                   ui->txrb6->setChecked (true);

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -492,6 +492,7 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
   m_block_udp_status_updates {false}
 {
   ui->setupUi(this);
+  m_watchdogAnchorUtc = QDateTime::currentDateTimeUtc ();
   setUnifiedTitleAndToolBarOnMac (true);
   createStatusBar();
   add_child_to_event_filter (this);
@@ -1381,7 +1382,21 @@ void MainWindow::on_the_minute ()
     // so it can time out as expected when no QSO starts.
     bool const pause_for_autocq = ui->cbAutoCQ->isChecked ()
                                   && m_QSOProgress == CALLING;
-    if (!pause_for_autocq && m_idleMinutes < watchdog ()) ++m_idleMinutes;
+    auto const now_utc = QDateTime::currentDateTimeUtc ();
+    if (!m_watchdogAnchorUtc.isValid ()) {
+      m_watchdogAnchorUtc = now_utc;
+    }
+    if (pause_for_autocq) {
+      // Freeze WD accrual while AutoCQ is parked in CALLING state.
+      m_watchdogAnchorUtc = now_utc;
+    } else {
+      int const elapsed_seconds = m_watchdogAnchorUtc.secsTo (now_utc);
+      if (elapsed_seconds >= 60 && m_idleMinutes < watchdog ()) {
+        int add_minutes = elapsed_seconds / 60;
+        m_idleMinutes = qMin (watchdog (), m_idleMinutes + add_minutes);
+        m_watchdogAnchorUtc = m_watchdogAnchorUtc.addSecs (add_minutes * 60);
+      }
+    }
     update_watchdog_label ();
   } else {
     // Do not silently reset idle minutes every minute when WD is disabled.
@@ -11584,6 +11599,7 @@ void MainWindow::tx_watchdog (bool triggered)
       if (ui->cbAutoCQ->isChecked()) {
                   ui->txrb6->setChecked (true);
                   m_idleMinutes = 0;
+                  m_watchdogAnchorUtc = QDateTime::currentDateTimeUtc ();
                   update_watchdog_label ();
                 } else {
                   if (m_auto) auto_tx_mode (false);
@@ -11600,6 +11616,7 @@ void MainWindow::tx_watchdog (bool triggered)
     {
       if (m_zdebug) log("TXWatchdog: FALSE");
       m_idleMinutes = 0;
+      m_watchdogAnchorUtc = QDateTime::currentDateTimeUtc ();
       update_watchdog_label ();
     }
   if (prior != triggered) statusUpdate ();

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -8223,6 +8223,14 @@ void MainWindow::on_dxCallEntry_textChanged (QString const& call)
   }*/
 
   set_dateTimeQSO (-1);  // reset the QSO start time when DXCall changes
+  auto const previous_base = Radio::base_callsign (m_hisCall);
+  auto const next_base = Radio::base_callsign (call);
+  if (watchdog () && !next_base.isEmpty () && previous_base != next_base)
+    {
+      // New DX target: start a fresh watchdog window instead of carrying
+      // any prior station's elapsed time into this QSO attempt.
+      tx_watchdog (false);
+    }
   m_hisCall = call;
   ui->dxGridEntry->clear();
   statusChanged();

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -5671,7 +5671,10 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
   if (m_zdebug) log("auto_sequence: " + message.string());
   auto const& message_words = message.messageWords ();
   auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
-  auto const selected_dx_base = Radio::base_callsign (ui->dxCallEntry->text ());
+  QString selected_dx_text = ui->dxCallEntry->text ().trimmed ();
+  if (selected_dx_text.isEmpty ()) selected_dx_text = m_hisCall.trimmed ();
+  if (selected_dx_text.isEmpty ()) selected_dx_text = m_nextCall.trimmed ();
+  auto const selected_dx_base = Radio::base_callsign (selected_dx_text);
   bool const have_selected_dx = !selected_dx_base.isEmpty ();
   auto msg_no_hash = message.clean_string();
   msg_no_hash = msg_no_hash.mid(22).remove("<").remove(">");
@@ -5727,21 +5730,27 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
     auto const target_base = normalized_base (message_words.at (3));
     auto const my_full_base = Radio::base_callsign (m_config.my_callsign ());
     bool const selected_dx_is_sender = have_selected_dx && sender_base == selected_dx_base;
+    bool const selected_dx_is_target = have_selected_dx && target_base == selected_dx_base;
+    bool const sender_is_me = sender_base == m_baseCall || sender_base == my_full_base;
     bool const target_is_me = target_base == m_baseCall || target_base == my_full_base;
+    bool const directed_with_selected_dx = selected_dx_is_sender || selected_dx_is_target;
+    bool const directed_to_me = sender_is_me || target_is_me;
 
     // Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
     bool const auto_qrm_guard_state = m_QSOProgress == CALLING
                       || m_QSOProgress == REPLYING
                       || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
+    bool const qrm_stop_window_match = m_QSOProgress == CALLING
+      || qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance);
     if (m_auto
         && auto_qrm_guard_state
-        && (SpecOp::HOUND != m_specOp) && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //
+        && (SpecOp::HOUND != m_specOp) && qrm_stop_window_match //
         && message_words.at (2) != "DE"
         && !message_words.at (2).contains (QRegularExpression {"(^(CQ|QRZ))|" + m_baseCall})
         && have_selected_dx
-        // Selected DX station is transmitting to another caller, not to us.
-      && selected_dx_is_sender
-      && !target_is_me) {
+        // Selected DX station is in a directed exchange with someone else, not us.
+      && directed_with_selected_dx
+      && !directed_to_me) {
       // auto stop to avoid accidental QRM
         // Z
         if (m_zdebug) log("Automatic TX halt");
@@ -5750,6 +5759,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
       if (ui->cbAutoCQ->isChecked() || ui->cbAutoCall->isChecked()) clearDX();
     } else if (m_auto             // transmit allowed
                && ui->cbAutoSeq->isChecked () // auto-sequencing allowed
+          && !(have_selected_dx && directed_with_selected_dx && !directed_to_me)
                && ((!m_bCallingCQ      // not calling CQ/QRZ
                     && !m_sentFirst73       // not finished QSO
                     && ((message_words.at (2).contains (m_baseCall)
@@ -5779,6 +5789,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
     } else if (ui->cbAutoSeq->isChecked()
                && message_words.at (2).contains (m_baseCall)
                && (ui->cbAutoCQ->isChecked() || ui->cbAutoCall->isChecked())
+               && !(have_selected_dx && directed_with_selected_dx && !directed_to_me)
                && m_QSOProgress == CALLING
                && !(message_words.filter (QRegularExpression {"^(73|RR73|RRR)$"}).size())
                && (m_config.processTailenders() || m_lastCall == hiscall)

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -3252,7 +3252,7 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
       // reset the Tx watchdog
       // Z
       if (m_config.wdResetAnywhere())
-      tx_watchdog (false);
+        reset_watchdog_on_click ();
       break;
 
     case QEvent::ChildAdded:
@@ -11656,6 +11656,34 @@ void MainWindow::tx_watchdog (bool triggered)
       update_watchdog_label ();
     }
   if (prior != triggered) statusUpdate ();
+}
+
+void MainWindow::reset_watchdog_on_click ()
+{
+  if (!watchdog () || m_mode == "WSPR" || m_mode == "FST4W") {
+    tx_watchdog (false);
+    return;
+  }
+
+  if (m_tx_watchdog) {
+    tx_watchdog (false);
+    return;
+  }
+
+  if (m_bTxTime) {
+    auto const now = QDateTime::currentDateTimeUtc ();
+    qint64 const ms = now.toMSecsSinceEpoch () % 86400000;
+    double const tsec = 0.001 * ms;
+    int const elapsed_seconds = int (fmod (tsec, m_TRperiod));
+
+    m_autoCQWatchdogPending = false;
+    m_watchdogAnchorUtc = now.addSecs (-elapsed_seconds);
+    m_idleMinutes = qMin (watchdog (), elapsed_seconds / 60.0);
+    update_watchdog_label ();
+    return;
+  }
+
+  tx_watchdog (false);
 }
 
 void MainWindow::update_watchdog_label ()

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -1053,6 +1053,7 @@ private:
   void subProcessError (QProcess *, QProcess::ProcessError);
   void statusUpdate () const;
   void update_watchdog_label ();
+  void reset_watchdog_on_click ();
   void invalidate_frequencies_filter ();
   void on_the_minute ();
   void add_child_to_event_filter (QObject *);

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -742,6 +742,7 @@ private:
   QScopedPointer<PSKReporterWidget> m_pskReporterView;
   QThread * m_pskReporterThread;
   QDateTime m_ignoreListReset;
+  QDateTime m_watchdogAnchorUtc;
   qint64 m_msTxFirst;
   bool m_TxFirstLock = false;
   bool m_AutoTxFreq = false;

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -439,7 +439,7 @@ private slots:
      void on_actionAbout_WSJT_Z_triggered();
      void on_pb_WDReset_clicked();
      void resetAutoSwitch();
-     int watchdog();
+    double watchdog();
      void on_actionUnfiltered_View_triggered();
      void on_actionPSKReporter_triggered();
      void updateQsoCounter(bool increment);
@@ -614,7 +614,7 @@ private:
   qint32  m_inGain;
   qint32  m_ncw;
   qint32  m_secID;
-  qint32  m_idleMinutes;
+  double  m_idleMinutes;
   qint32  m_nSubMode;
   qint32  m_nSubMode_Q65;
   qint32  m_nSubMode_JT65;

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -960,6 +960,7 @@ private:
   bool m_tx_when_ready;
   bool m_transmitting;
   bool m_tune;
+  bool m_autoCQWatchdogPending;
   bool m_tx_watchdog;           // true when watchdog triggered
   bool m_block_pwr_tooltip;
   bool m_PwrBandSetOK;


### PR DESCRIPTION
In on_dxCallEntry_textChanged, I compare previous and new base callsigns. If watchdog is enabled, the new target is non-empty, and the base call actually changed, I call tx_watchdog(false) before updating m_hisCall. This ensures each newly selected station starts with a fresh watchdog window instead of inheriting elapsed time from the prior station.