### PR TITLE
PR33 refactor on QRM issues

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -8239,6 +8239,14 @@ void MainWindow::on_dxCallEntry_textChanged (QString const& call)
   }*/
 
   set_dateTimeQSO (-1);  // reset the QSO start time when DXCall changes
+  auto const previous_base = Radio::base_callsign (m_hisCall);
+  auto const next_base = Radio::base_callsign (call);
+  if (watchdog () && !next_base.isEmpty () && previous_base != next_base)
+    {
+      // New DX target: start a fresh watchdog window instead of carrying
+      // any prior station's elapsed time into this QSO attempt.
+      tx_watchdog (false);
+    }
   m_hisCall = call;
   ui->dxGridEntry->clear();
   statusChanged();

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -1376,13 +1376,17 @@ void MainWindow::on_the_minute ()
         }
     }
   // Z
-  if (watchdog () && m_mode!="WSPR" && m_mode!="FST4W"
-      && !((ui->cbAutoCQ->isChecked() || ui->cbAutoCall->isChecked())
-           && m_QSOProgress == CALLING)) {
-    if (m_idleMinutes < watchdog ()) ++m_idleMinutes;
+  if (watchdog () && m_mode!="WSPR" && m_mode!="FST4W") {
+    // Keep AutoCQ's existing CALLING pause behavior, but let AutoCall obey WD
+    // so it can time out as expected when no QSO starts.
+    bool const pause_for_autocq = ui->cbAutoCQ->isChecked ()
+                                  && m_QSOProgress == CALLING;
+    if (!pause_for_autocq && m_idleMinutes < watchdog ()) ++m_idleMinutes;
     update_watchdog_label ();
   } else {
-    tx_watchdog (false);
+    // Do not silently reset idle minutes every minute when WD is disabled.
+    if (m_tx_watchdog) tx_watchdog (false);
+    else update_watchdog_label ();
   }
   update_foxLogWindow_rate(); // update the rate on the window
   if ((!verified && ui->labDXped->isVisible()) or !ui->labDXped->text().contains("Hound"))
@@ -5725,7 +5729,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
     bool const selected_dx_is_sender = have_selected_dx && sender_base == selected_dx_base;
     bool const target_is_me = target_base == m_baseCall || target_base == my_full_base;
 
-	// Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
+    // Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
     bool const auto_qrm_guard_state = m_QSOProgress == CALLING
                                       || m_QSOProgress == REPLYING
                                       || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
@@ -6973,9 +6977,6 @@ void MainWindow::doubleClickOnCall2(Qt::KeyboardModifiers modifiers)
 
 void MainWindow::doubleClickOnCall(Qt::KeyboardModifiers modifiers)
 {
-  // Z
-  tx_watchdog(false);
-
   QTextCursor cursor;
   if(m_mode=="FST4W") {
     MessageBox::information_message (this,
@@ -7023,6 +7024,9 @@ void MainWindow::doubleClickOnCall(Qt::KeyboardModifiers modifiers)
     }
     return;
   }
+
+  // Valid call selection starts a fresh WD window.
+  tx_watchdog(false);
   m_bDoubleClicked = true;
   m_hisCall0 = m_hisCall;
   processMessage (message, modifiers);
@@ -11537,7 +11541,34 @@ void MainWindow::tx_watchdog (bool triggered)
       m_bTxTime=false;
       // Z
       if (ui->cbAutoCall->isChecked() && ui->cb_IgnoreAfterWD->isChecked())
-          ui->pte_IgnoredStations->appendPlainText(m_hisCall);
+        {
+          auto const active_call = ui->dxCallEntry->text().trimmed();
+          auto const his_call = m_hisCall.trimmed();
+          auto const ignore_candidate = active_call.isEmpty () ? his_call : active_call;
+          auto const candidate_base = Radio::base_callsign (ignore_candidate);
+          auto const his_base = Radio::base_callsign (his_call);
+          bool const same_target = !candidate_base.isEmpty ()
+                                   && !his_base.isEmpty ()
+                                   && candidate_base == his_base;
+          bool const already_ignored = m_ignoredStationsCache.contains (ignore_candidate)
+                                       || m_ignoredStationsCache.contains (candidate_base);
+
+          if (m_QSOProgress == CALLING
+              && same_target
+              && !ignore_candidate.isEmpty ()
+              && !already_ignored)
+            {
+              ui->pte_IgnoredStations->appendPlainText(ignore_candidate);
+              if (m_zdebug) log("TXWatchdog: Added to ignore list after WD timeout: " + ignore_candidate);
+            }
+          else if (m_zdebug)
+            {
+              log("TXWatchdog: Skip ignore-list add (candidate='" + ignore_candidate
+                  + "', same_target=" + QString::number (same_target)
+                  + ", calling_state=" + QString::number (m_QSOProgress == CALLING)
+                  + ", already_ignored=" + QString::number (already_ignored) + ")");
+            }
+        }
 
       if (ui->cbAutoCQ->isChecked()) {
                   ui->txrb6->setChecked (true);

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -5667,6 +5667,8 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
   if (m_zdebug) log("auto_sequence: " + message.string());
   auto const& message_words = message.messageWords ();
   auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
+  auto const selected_dx_base = Radio::base_callsign (ui->dxCallEntry->text ());
+  bool const have_selected_dx = !selected_dx_base.isEmpty ();
   auto msg_no_hash = message.clean_string();
   msg_no_hash = msg_no_hash.mid(22).remove("<").remove(">");
 
@@ -5711,17 +5713,31 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
     message.deCallAndGrid(/*out*/hiscall,hisgrid);
     bool addressed_to_me = message_words.at (2).contains (m_baseCall);
     bool tailender_ok = (m_config.processTailenders() || m_lastCall == hiscall || !m_bAutoReply);
+    auto normalized_base = [](QString token)
+      {
+        token.remove ('<');
+        token.remove ('>');
+        return Radio::base_callsign (token);
+      };
+    auto const sender_base = normalized_base (message_words.at (2));
+    auto const target_base = normalized_base (message_words.at (3));
+    auto const my_full_base = Radio::base_callsign (m_config.my_callsign ());
+    bool const selected_dx_is_sender = have_selected_dx && sender_base == selected_dx_base;
+    bool const target_is_me = target_base == m_baseCall || target_base == my_full_base;
 
 	// Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
+    bool const auto_qrm_guard_state = m_QSOProgress == CALLING
+                                      || m_QSOProgress == REPLYING
+                                      || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
     if (m_auto
-        && (m_QSOProgress==REPLYING  or (!ui->tx1->isEnabled () and m_QSOProgress==REPORT))
+        && auto_qrm_guard_state
         && (SpecOp::HOUND != m_specOp) && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //
         && message_words.at (2) != "DE"
         && !message_words.at (2).contains (QRegularExpression {"(^(CQ|QRZ))|" + m_baseCall})
+        && have_selected_dx
         // Selected DX station is transmitting to another caller, not to us.
-        && message_words.at (2).contains (Radio::base_callsign (ui->dxCallEntry->text ()))
-        && !message_words.at (3).contains (m_baseCall)
-        && !message_words.at (3).contains (m_config.my_callsign ())) {
+        && selected_dx_is_sender
+        && !target_is_me) {
       // auto stop to avoid accidental QRM
         // Z
         if (m_zdebug) log("Automatic TX halt");

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -5928,21 +5928,35 @@ void MainWindow::guiUpdate()
   m_tRemaining=m_TRperiod - fmod(tsec,m_TRperiod);
   update_mode_switch_status_label ();
 
-  // Reset FT8 MTD dedup buffer on period boundaries (~2 s before the cycle's
-  // early decode fires). Mirrors wsjtx-improved:8296. Paired with removing the
-  // reset inside decode(), which was wiping the buffer between the early and
-  // final passes of the SAME cycle.
-  if (m_mode == "FT8") {
-    int const s_in_min = nsec % 60;
-    if (s_in_min == 10 || s_in_min == 25 || s_in_min == 40 || s_in_min == 55) {
-      static int s_lastReset = -1;
-      if (s_in_min != s_lastReset) {
-        earlyDecodes = "";
-        m_nDecodes = 0;
-        ndecodes_label.setText("0");
-        s_lastReset = s_in_min;
+  // Reset FT8 MTD dedup buffer once per cycle near the end of the period so
+  // the next cycle starts clean, while preserving early/final pass dedup for
+  // the current cycle. Using cycle phase is more robust than fixed UTC marks
+  // when mode/clock boundaries drift.
+  {
+    static qint64 s_lastResetCycle = -1;
+    static bool s_prevModeWasFT8 = false;
+
+    if (m_mode == "FT8" && m_TRperiod > 0.0)
+      {
+        double const cycle_phase = fmod (tsec, m_TRperiod);
+        qint64 const cycle_index = static_cast<qint64> (tsec / m_TRperiod);
+        double const reset_phase = (m_TRperiod > 2.0) ? (m_TRperiod - 2.0) : 0.0;
+
+        if (cycle_phase >= reset_phase && cycle_index != s_lastResetCycle)
+          {
+            earlyDecodes = "";
+            m_nDecodes = 0;
+            ndecodes_label.setText("0");
+            s_lastResetCycle = cycle_index;
+          }
+        s_prevModeWasFT8 = true;
       }
-    }
+    else if (s_prevModeWasFT8)
+      {
+        // Clear cycle latch when leaving FT8 so re-entry cannot miss first reset.
+        s_lastResetCycle = -1;
+        s_prevModeWasFT8 = false;
+      }
   }
 
   if(m_mode=="Echo") {

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -5731,8 +5731,8 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
 
     // Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
     bool const auto_qrm_guard_state = m_QSOProgress == CALLING
-                                      || m_QSOProgress == REPLYING
-                                      || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
+        || m_QSOProgress == REPLYING
+        || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
     if (m_auto
         && auto_qrm_guard_state
         && (SpecOp::HOUND != m_specOp) && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //
@@ -5740,8 +5740,8 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
         && !message_words.at (2).contains (QRegularExpression {"(^(CQ|QRZ))|" + m_baseCall})
         && have_selected_dx
         // Selected DX station is transmitting to another caller, not to us.
-        && selected_dx_is_sender
-        && !target_is_me) {
+      && selected_dx_is_sender
+      && !target_is_me) {
       // auto stop to avoid accidental QRM
         // Z
         if (m_zdebug) log("Automatic TX halt");

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -5731,8 +5731,8 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
 
     // Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
     bool const auto_qrm_guard_state = m_QSOProgress == CALLING
-        || m_QSOProgress == REPLYING
-        || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
+                      || m_QSOProgress == REPLYING
+                      || (!ui->tx1->isEnabled () && m_QSOProgress == REPORT);
     if (m_auto
         && auto_qrm_guard_state
         && (SpecOp::HOUND != m_specOp) && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //


### PR DESCRIPTION
Expanded the auto-stop state gate to include CALLING as well as REPLYING/REPORT in mainwindow.cpp:5735. Kept stop_tolerance frequency proximity behavior (did not remove it), so halts stay targeted. Added normalized base-callsign matching for sender/target tokens to reduce false matches from substring contains logic in mainwindow.cpp:5720. Kept the safer sender-only DX condition:
Stop only when selected DX is the sender and target is not you. Did not adopt PR33’s selected-DX-in-target halt rule, which can create false stops.