### PR TITLE
synch with checkbox and combobox

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -1852,6 +1852,7 @@ void MainWindow::readSettings()
   m_minSync=m_settings->value("MinSync",0).toInt();
   ui->syncSpinBox->setValue(m_minSync);
   ui->cbAutoSeq->setChecked (m_settings->value ("AutoSeq", false).toBool());
+  ui->cbFirst->setChecked (ui->respondComboBox->currentIndex() == 1);
   ui->cbRxAll->setChecked (m_settings->value ("RxAll", false).toBool());
 // m_bShMsgs=m_settings->value("ShMsgs",false).toBool();
   m_bSWL=m_settings->value("SWL",false).toBool();
@@ -11568,6 +11569,28 @@ void MainWindow::on_cbAutoSeq_toggled(bool b)
 {
   ui->respondComboBox->setVisible((m_mode=="FT8" or m_mode=="FT4" or m_mode=="FT2" or m_mode=="FST4"
                            or m_mode=="Q65") and b);
+}
+
+void MainWindow::on_cbFirst_toggled(bool checked)
+{
+  auto const desired_index = checked ? 1 : 0;   // CQ: First or CQ: None
+  if (ui->respondComboBox->currentIndex() != desired_index)
+    {
+      auto const blocked = ui->respondComboBox->blockSignals(true);
+      ui->respondComboBox->setCurrentIndex(desired_index);
+      ui->respondComboBox->blockSignals(blocked);
+    }
+}
+
+void MainWindow::on_respondComboBox_currentIndexChanged(int index)
+{
+  auto const call_first = (index == 1);         // only CQ: First means checked
+  if (ui->cbFirst->isChecked() != call_first)
+    {
+      auto const blocked = ui->cbFirst->blockSignals(true);
+      ui->cbFirst->setChecked(call_first);
+      ui->cbFirst->blockSignals(blocked);
+    }
 }
 
 void MainWindow::on_measure_check_box_stateChanged (int state)

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -308,6 +308,8 @@ private slots:
   void on_cbMenus_toggled(bool b);
   void on_cbCQonly_toggled(bool b);
   void on_cbAutoSeq_toggled(bool b);
+  void on_cbFirst_toggled(bool checked);
+  void on_respondComboBox_currentIndexChanged(int index);
   void networkError (QString const&);
   void on_ClrAvgButton_clicked();
   void on_actionWSPR_triggered();


### PR DESCRIPTION
If CallFirst was previously saved in main window settings, that saved value is used. If not, it defaults to your “Calling CQ forces Call 1st” Configuration setting.