### PR TITLE
click-tx-erase

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -3244,7 +3244,7 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
           ui->dxCallEntry->clear();
           ui->dxGridEntry->clear();
           ui->txrb6->setChecked(true);
-          if (ui->cbAutoCall->isChecked() || ui->cb_autoCQ->isChecked()) {
+          if (ui->cbAutoCall->isChecked()) {
             m_btxok=false;
             m_bCallingCQ = false;
             m_bAutoReply = false;         // ready for next
@@ -5880,7 +5880,7 @@ void MainWindow::on_EraseButton_clicked ()
     ui->dxCallEntry->clear();
     ui->dxGridEntry->clear();
     ui->txrb6->setChecked(true);
-    if (ui->cbAutoCall->isChecked() || ui->cbAutoCQ->isChecked()) {
+    if (ui->cbAutoCall->isChecked()) {
       m_btxok=false;
       m_bCallingCQ = false;
       m_bAutoReply = false;         // ready for next

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -327,6 +327,7 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
   m_rx_audio_buffer_frames {0},
   m_tx_audio_buffer_frames {0},
   m_msErase {0},
+  m_nEraseClicks {0},
   m_secBandChanged {0},
   m_freqNominal {0},
   m_freqNominalPeriod {0},
@@ -3232,6 +3233,23 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
       // Z
       if (m_config.wdResetAnywhere())
       tx_watchdog (false);
+      if (object == ui->EraseButton) {
+        auto const *mouseEvent = static_cast<QMouseEvent const *> (event);
+        if (mouseEvent->button() == Qt::RightButton) {
+          ui->tx1->clear();
+          ui->tx2->clear();
+          ui->tx3->clear();
+          ui->tx4->clear();
+          ui->tx5->clearEditText();
+          ui->dxCallEntry->clear();
+          ui->dxGridEntry->clear();
+          ui->txrb6->setChecked(true);
+          if (ui->cbAutoCall->isChecked() && m_bDoubleClicked) {
+            on_stopTxButton_clicked();
+          }
+          return true; // eat the event
+        }
+      }
       break;
 
     case QEvent::ChildAdded:
@@ -5833,18 +5851,36 @@ void MainWindow::killFile ()
 
 void MainWindow::on_EraseButton_clicked ()
 {
-  qint64 ms=QDateTime::currentMSecsSinceEpoch();
-  ui->decodedTextBrowser2->erase ();
-  if(m_mode=="WSPR" or m_mode=="Echo" or m_mode=="FST4W") {
-    ui->decodedTextBrowser->erase ();
-  } else {
-    if((ms-m_msErase)<500) {
-      ui->decodedTextBrowser->erase ();
-      // Z
-      if (m_unfilteredView) m_unfilteredView->erase();
-    }
+  qint64 ms = QDateTime::currentMSecsSinceEpoch();
+  if ((ms - m_msErase) > 500) {
+    m_nEraseClicks = 0;
   }
-  m_msErase=ms;
+
+  ++m_nEraseClicks;
+  ui->decodedTextBrowser2->erase ();
+
+  bool eraseBoth = (m_mode=="WSPR" or m_mode=="Echo" or m_mode=="FST4W") || (m_nEraseClicks >= 2);
+  if (eraseBoth) {
+    ui->decodedTextBrowser->erase (); 
+    if (m_unfilteredView) m_unfilteredView->erase();
+  }
+
+  if (m_nEraseClicks >= 3) {
+    ui->tx1->clear();
+    ui->tx2->clear();
+    ui->tx3->clear();
+    ui->tx4->clear();
+    ui->tx5->clearEditText();
+    ui->dxCallEntry->clear();
+    ui->dxGridEntry->clear();
+    ui->txrb6->setChecked(true);
+    if (ui->cbAutoCall->isChecked() && m_bDoubleClicked) {
+      on_stopTxButton_clicked();
+    }
+    m_nEraseClicks = 0;
+  }
+
+  m_msErase = ms;
 }
 
 void MainWindow::band_activity_cleared ()

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -3244,7 +3244,7 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
           ui->dxCallEntry->clear();
           ui->dxGridEntry->clear();
           ui->txrb6->setChecked(true);
-          if (ui->cbAutoCall->isChecked()) {
+          if (ui->cbAutoCall->isChecked() || ui->cb_autoCQ->isChecked()) {
             m_btxok=false;
             m_bCallingCQ = false;
             m_bAutoReply = false;         // ready for next
@@ -5880,7 +5880,7 @@ void MainWindow::on_EraseButton_clicked ()
     ui->dxCallEntry->clear();
     ui->dxGridEntry->clear();
     ui->txrb6->setChecked(true);
-    if (ui->cbAutoCall->isChecked()) {
+    if (ui->cbAutoCall->isChecked() || ui->cbAutoCQ->isChecked()) {
       m_btxok=false;
       m_bCallingCQ = false;
       m_bAutoReply = false;         // ready for next

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -3244,8 +3244,14 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
           ui->dxCallEntry->clear();
           ui->dxGridEntry->clear();
           ui->txrb6->setChecked(true);
-          if (ui->cbAutoCall->isChecked() && m_bDoubleClicked) {
-            on_stopTxButton_clicked();
+          if (ui->cbAutoCall->isChecked()) {
+            m_btxok=false;
+            m_bCallingCQ = false;
+            m_bAutoReply = false;         // ready for next
+            ui->autoButton->setChecked (false);
+            on_autoButton_clicked (false);
+            stopWRTimer.stop();           // stop a running Tx3 timer
+            if (m_zdebug) log("Tx stopped by right-click on Erase button");
           }
           return true; // eat the event
         }
@@ -5874,8 +5880,14 @@ void MainWindow::on_EraseButton_clicked ()
     ui->dxCallEntry->clear();
     ui->dxGridEntry->clear();
     ui->txrb6->setChecked(true);
-    if (ui->cbAutoCall->isChecked() && m_bDoubleClicked) {
-      on_stopTxButton_clicked();
+    if (ui->cbAutoCall->isChecked()) {
+      m_btxok=false;
+      m_bCallingCQ = false;
+      m_bAutoReply = false;         // ready for next
+      ui->autoButton->setChecked (false);
+      on_autoButton_clicked (false);
+      stopWRTimer.stop();           // stop a running Tx3 timer
+      if (m_zdebug) log("Auto-sequencing stopped by triple Erase click");
     }
     m_nEraseClicks = 0;
   }

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -571,6 +571,7 @@ private:
   QThread m_audioThread;
 
   qint64  m_msErase;
+  int     m_nEraseClicks;
   qint64  m_secBandChanged;
   qint64  m_freqMoon;
   qint64  m_fullFoxCallTime;

--- a/widgets/mainwindow.ui
+++ b/widgets/mainwindow.ui
@@ -107,7 +107,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Erase right window. Double-click to erase both windows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Erase right window. Double-click to erase both windows. Triple-click also clears Tx1-Tx5, DX call, and DX grid. Right-click clears only Tx1-Tx5 and DX entries.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>&amp;Erase</string>


### PR DESCRIPTION
Added a triple-click counter for the Erase button in mainwindow.h Updated MainWindow::on_EraseButton_clicked() in mainwindow.cpp: 1st click: erase right decoded window
2nd click: erase both decoded windows
3rd click: also clear tx1, tx2, tx3, tx4, and tx5