### PR TITLE
pile-up-mode

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -815,6 +815,7 @@ private:
   bool disableWriteALL_;
   bool disableWriteFoxQSO_;
   bool colourAll_;
+  bool pileupMode_;
   bool autoCQfiltering_;
   bool rxTotxFreq_;
   bool udpFiltering_;
@@ -971,6 +972,15 @@ bool Configuration::disableWriteALL() const {return m_->disableWriteALL_;}
 bool Configuration::disableWriteFoxQSO() const {return m_->disableWriteFoxQSO_;}
 bool Configuration::colourAll() const {return m_->colourAll_;}
 bool Configuration::autoCQfiltering() const {return m_->autoCQfiltering_;}
+void Configuration::setPileupMode(bool enabled, bool autoCQfiltering)
+{
+  m_->pileupMode_ = enabled;
+  m_->autoCQfiltering_ = autoCQfiltering;
+  m_->ui_->cb_autoCQfiltering->setChecked(autoCQfiltering);
+  m_->settings_->setValue("pileupMode", enabled);
+  m_->settings_->setValue("autoCQfiltering", autoCQfiltering);
+}
+bool Configuration::pileupMode() const {return m_->pileupMode_;}
 bool Configuration::rxTotxFreq() const {return m_->rxTotxFreq_;}
 bool Configuration::udpFiltering() const {return m_->udpFiltering_;}
 bool Configuration::highlightDX() const {return m_->highlightDX_;}
@@ -2094,6 +2104,7 @@ void Configuration::impl::read_settings ()
   disableWriteALL_ = settings_->value("disableWriteALL").toBool();
   disableWriteFoxQSO_ = settings_->value("disableWriteFoxQSO").toBool();
   colourAll_ = settings_->value("colourAll").toBool();
+  pileupMode_ = settings_->value("pileupMode", false).toBool();
   autoCQfiltering_ = settings_->value("autoCQfiltering").toBool();
   rxTotxFreq_ = settings_->value("rxTotxFreq").toBool();
   udpFiltering_ = settings_->value("udpFiltering").toBool();
@@ -2291,6 +2302,7 @@ void Configuration::impl::write_settings ()
   settings_->setValue("disableWriteALL", disableWriteALL_);
   settings_->setValue("disableWriteFoxQSO", disableWriteFoxQSO_);
   settings_->setValue("colourAll", colourAll_);
+  settings_->setValue("pileupMode", pileupMode_);
   settings_->setValue("autoCQfiltering", autoCQfiltering_);
   settings_->setValue("rxTotxFreq", rxTotxFreq_);
   settings_->setValue("udpFiltering", udpFiltering_);

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -215,6 +215,8 @@ public:
   bool disableWriteFoxQSO() const;
   bool colourAll() const;
   bool autoCQfiltering() const;
+  void setPileupMode(bool enabled, bool autoCQfiltering);
+  bool pileupMode() const;
   bool rxTotxFreq() const;
   bool udpFiltering() const;
   bool highlightDX() const;

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -1975,6 +1975,8 @@ void MainWindow::readSettings()
   }
   m_settings->endGroup();
 
+  update_auto_call_pileup_mode_ui();
+
   // use these initialisation settings to tune the audio o/p buffer
   // size and audio thread priority
   m_settings->beginGroup ("Tune");
@@ -3311,6 +3313,20 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
     case QEvent::KeyPress:
       // fall through
     case QEvent::MouseButtonPress:
+      if (object == ui->cbAutoCall)
+        {
+          auto const* mouse = static_cast<QMouseEvent const *> (event);
+          if (mouse->button () == Qt::RightButton)
+            {
+              bool const enable_pileup_mode = !m_config.pileupMode ();
+              if (enable_pileup_mode && !ui->cb_filtering->isChecked())
+                {
+                  ui->cb_filtering->setChecked(true);
+                }
+              apply_pileup_mode_side_effects(enable_pileup_mode);
+              return true;
+            }
+        }
       // reset the Tx watchdog
       // Z
       if (m_config.wdResetAnywhere())
@@ -3595,6 +3611,24 @@ void MainWindow::setup_status_bar (bool vhf)
   } else {
     if (band_hopping_label.isVisible ()) statusBar ()->removeWidget (&band_hopping_label);
   }
+}
+
+void MainWindow::update_auto_call_pileup_mode_ui()
+{
+  bool const pileup_mode = m_config.pileupMode ();
+  QString const state = pileup_mode ? tr ("ON") : tr ("OFF");
+  ui->cbAutoCall->setToolTip (
+      tr ("Auto Call mode, Similarly to Auto CQ, but the earth doesn't implode. Gluten free. Right-click to toggle pileup mode (directed-call responses only): %1")
+      .arg (state));
+
+  if (pileup_mode)
+    {
+      ui->cbAutoCall->setStyleSheet ("QCheckBox { color: #cc0000; font-weight: 700; }");
+    }
+  else
+    {
+      ui->cbAutoCall->setStyleSheet (QString {});
+    }
 }
 
 bool MainWindow::subProcessFailed (QProcess * process, int exit_code, QProcess::ExitStatus status)
@@ -13496,6 +13530,7 @@ void MainWindow::on_cbAutoCall_toggled(bool b)
         ui->cb_filtering->setEnabled(true);
     }
 
+    update_auto_call_pileup_mode_ui();
     auto_tx_mode(false);
   update_mode_switch_status_label ();
 }
@@ -14634,6 +14669,55 @@ void MainWindow::on_cb_filtering_toggled(bool b) {
     } else {
        ui->cb_filtering->setStyleSheet("");
     }
+}
+
+void MainWindow::apply_pileup_mode_side_effects(bool enabled)
+{
+  if (enabled) {
+    if (!m_savedAutoCQfilteringValid) {
+      m_savedAutoCQfiltering = m_config.autoCQfiltering();
+      m_savedContinentEU = ui->cb_c_EU->isChecked();
+      m_savedContinentAF = ui->cb_c_AF->isChecked();
+      m_savedContinentAN = ui->cb_c_AN->isChecked();
+      m_savedContinentAS = ui->cb_c_AS->isChecked();
+      m_savedContinentNA = ui->cb_c_NA->isChecked();
+      m_savedContinentSA = ui->cb_c_SA->isChecked();
+      m_savedContinentOC = ui->cb_c_OC->isChecked();
+      m_savedAutoCQfilteringValid = true;
+    }
+    m_config.setPileupMode(true, false);
+    ui->cb_c_EU->setChecked(false);
+    ui->cb_c_AF->setChecked(false);
+    ui->cb_c_AN->setChecked(false);
+    ui->cb_c_AS->setChecked(false);
+    ui->cb_c_NA->setChecked(false);
+    ui->cb_c_SA->setChecked(false);
+    ui->cb_c_OC->setChecked(false);
+  } else {
+    bool auto_cq_filtering = false;
+    if (m_savedAutoCQfilteringValid) {
+      auto_cq_filtering = m_savedAutoCQfiltering;
+      ui->cb_c_EU->setChecked(m_savedContinentEU);
+      ui->cb_c_AF->setChecked(m_savedContinentAF);
+      ui->cb_c_AN->setChecked(m_savedContinentAN);
+      ui->cb_c_AS->setChecked(m_savedContinentAS);
+      ui->cb_c_NA->setChecked(m_savedContinentNA);
+      ui->cb_c_SA->setChecked(m_savedContinentSA);
+      ui->cb_c_OC->setChecked(m_savedContinentOC);
+    } else {
+      ui->cb_c_EU->setChecked(true);
+      ui->cb_c_AF->setChecked(true);
+      ui->cb_c_AN->setChecked(true);
+      ui->cb_c_AS->setChecked(true);
+      ui->cb_c_NA->setChecked(true);
+      ui->cb_c_SA->setChecked(true);
+      ui->cb_c_OC->setChecked(true);
+    }
+    m_savedAutoCQfilteringValid = false;
+    m_config.setPileupMode(false, auto_cq_filtering);
+  }
+
+  update_auto_call_pileup_mode_ui();
 }
 
 void MainWindow::on_cb_specialMode_currentIndexChanged (int index)

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -764,6 +764,16 @@ private:
   QDateTime m_ignoreListReset;
   qint64 m_msTxFirst;
   bool m_TxFirstLock = false;
+  bool m_savedAutoCQfiltering = false;
+  bool m_savedProcessTailenders = false;
+  bool m_savedAutoCQfilteringValid = false;
+  bool m_savedContinentEU = true;
+  bool m_savedContinentAF = true;
+  bool m_savedContinentAN = true;
+  bool m_savedContinentAS = true;
+  bool m_savedContinentNA = true;
+  bool m_savedContinentSA = true;
+  bool m_savedContinentOC = true;
   bool m_AutoTxFreq = false;
   int qso_total = 0;
   int qso_new = 0;
@@ -1004,6 +1014,7 @@ private:
   void qrzLookup(QString dxCall);
   void qrzVisible(bool b);
   void clearCallInfo();
+  void apply_pileup_mode_side_effects(bool enabled);
   QString  stateLookup(QString callsign);
   QString leftJustifyAppendage (QString message, QString appendage);
   void updateBandActivityTitleLabel();
@@ -1017,6 +1028,7 @@ private:
   void createStatusBar();
   void update_mode_switch_status_label();
   void update_auto_mode_switch_widget();
+  void update_auto_call_pileup_mode_ui();
   void updateStatusBar();
   void genStdMsgs(QString rpt, bool unconditional = false);
   void genCQMsg();


### PR DESCRIPTION
Right-click Auto Call: toggles pileup mode.
Pileup mode ON: Auto Call label turns red

this will temporary disable all continents as a filter to only enable respond to all calls to us and disable filter calls to us.

thus, working the pileup without adding to it.