### PR TITLE
Fix build with modern GCC/gfortran 14+

### DIFF
--- a/Transceiver/HRDTransceiver.cpp
+++ b/Transceiver/HRDTransceiver.cpp
@@ -1062,6 +1062,10 @@ QString HRDTransceiver::send_command (QString const& cmd, bool prepend_context, 
     }
   else
     {
+#if defined (__GNUC__) && !defined (__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
       auto string = prepend_context ? context + cmd : cmd;
       QScopedPointer<HRDMessage> message {new (string) HRDMessage};
       if (!write_to_port (reinterpret_cast<char const *> (message.data ()), message->size_))
@@ -1072,6 +1076,9 @@ QString HRDTransceiver::send_command (QString const& cmd, bool prepend_context, 
               .arg (cmd)
               };
         }
+#if defined (__GNUC__) && !defined (__clang__)
+#pragma GCC diagnostic pop
+#endif
     }
   auto buffer = read_reply (cmd);
   if (v4 == protocol_)

--- a/lib/jplsubs.f
+++ b/lib/jplsubs.f
@@ -533,7 +533,7 @@ C
 
 C+++++++++++++++++++++++++
 C
-      SUBROUTINE SPLIT(TT,FR)
+      SUBROUTINE JPLSPLIT(TT,FR)
 C
 C+++++++++++++++++++++++++
 C
@@ -754,11 +754,11 @@ C       ********** MAIN ENTRY POINT **********
       IF(ET2(1) .EQ. 0.D0) RETURN
 
       S=ET2(1)-.5D0
-      CALL SPLIT(S,PJD(1))
-      CALL SPLIT(ET2(2),PJD(3))
+      CALL JPLSPLIT(S,PJD(1))
+      CALL JPLSPLIT(ET2(2),PJD(3))
       PJD(1)=PJD(1)+PJD(3)+.5D0
       PJD(2)=PJD(2)+PJD(4)
-      CALL SPLIT(PJD(2),PJD(3))
+      CALL JPLSPLIT(PJD(2),PJD(3))
       PJD(1)=PJD(1)+PJD(3)
 
 C       ERROR RETURN FOR EPOCH OUT OF RANGE


### PR DESCRIPTION
- lib/jplsubs.f: rename local SPLIT subroutine to JPLSPLIT to avoid clashing with gfortran 14's new Fortran 2023 SPLIT intrinsic
- Transceiver/HRDTransceiver.cpp: suppress spurious GCC -Wmaybe-uninitialized around placement-new HRDMessage usage

https://github.com/sq9fve/wsjt-z/issues/75

forced into a PR here due to security issues?

I did test this compile on debian26,24 OSX and JTSDK4111 all passed build.