### PR TITLE
Revert UDP security - fix

### DIFF
--- a/UDPExamples/MessageServer.cpp
+++ b/UDPExamples/MessageServer.cpp
@@ -468,8 +468,7 @@ MessageServer::MessageServer (QObject * parent, QString const& version, QString 
 }
 
 void MessageServer::start (port_type port, QHostAddress const& multicast_group_address
-                           , QSet<QString> const& network_interface_names
-                           , QHostAddress const& bind_address)
+                           , QSet<QString> const& network_interface_names)
 {
   // qDebug () << "MessageServer::start port:" << port << "multicast addr:" << multicast_group_address.toString () << "network interfaces:" << network_interface_names;
   if (port != m_->localPort ()
@@ -493,14 +492,8 @@ void MessageServer::start (port_type port, QHostAddress const& multicast_group_a
         {
           m_->multicast_group_address_ = multicast_group_address;
           m_->network_interfaces_ = network_interface_names;
-          // A caller-supplied bind_address (e.g. QHostAddress::LocalHost)
-          // takes precedence and restricts the listener to that address;
-          // this is used by the WSJT-Z control server so it is not exposed
-          // on all network interfaces. Multicast requires an "any" bind.
-          QHostAddress local_addr {!bind_address.isNull () && !is_multicast_address (multicast_group_address)
-                                   ? bind_address
-                                   : (is_multicast_address (multicast_group_address)
-                                      && impl::IPv4Protocol == multicast_group_address.protocol () ? QHostAddress::AnyIPv4 : QHostAddress::Any)};
+          QHostAddress local_addr {is_multicast_address (multicast_group_address)
+                                   && impl::IPv4Protocol == multicast_group_address.protocol () ? QHostAddress::AnyIPv4 : QHostAddress::Any};
           if (port && m_->bind (local_addr, port, m_->bind_mode_))
             {
               m_->join_multicast_group ();

--- a/UDPExamples/MessageServer.hpp
+++ b/UDPExamples/MessageServer.hpp
@@ -41,14 +41,10 @@ public:
 
   // start or restart the server, if the multicast_group_address
   // argument is given it is assumed to be a multicast group address
-  // which the server will join. If bind_address is given (non-null and
-  // non-multicast) the listening socket is bound to that address only
-  // (e.g. QHostAddress::LocalHost to restrict access to this host);
-  // otherwise it binds all interfaces as before.
+  // which the server will join
   Q_SLOT void start (port_type port
                      , QHostAddress const& multicast_group_address = QHostAddress {}
-                     , QSet<QString> const& network_interface_names = QSet<QString> {}
-                     , QHostAddress const& bind_address = QHostAddress {});
+                     , QSet<QString> const& network_interface_names = QSet<QString> {});
 
   // stop the server
   Q_SLOT void stop ();

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -723,25 +723,17 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
     this->remote_configure (mode, frequency_tolerance, submode, fast_mode, tr_period, rx_df, dx_call, dx_grid, generate_messages, auto_cq_enabled, auto_call_enabled);
   });
   
-  // Only start listening if accept_udp_requests is enabled. The control
-  // surface can start automated TX, so bind it to the configured "UDP
-  // Server" address (defaults to 127.0.0.1, i.e. this host only). Set that
-  // field to 0.0.0.0 to deliberately expose it. If the value is not a
-  // literal IP (e.g. a hostname) fall back to localhost to stay safe.
+  // Only start listening if accept_udp_requests is enabled
   if (m_config.accept_udp_requests ())
     {
-      QHostAddress bind_addr {m_config.udp_server_name ()};
-      m_udp_server->start (m_config.udp_server_port (), QHostAddress {}, QSet<QString> {},
-                           bind_addr.isNull () ? QHostAddress {QHostAddress::LocalHost} : bind_addr);
+      m_udp_server->start (m_config.udp_server_port ());
     }
-
+  
   // Handle accept_udp_requests checkbox changes
   connect (&m_config, &Configuration::accept_udp_requests_changed, [this] (bool enable) {
     if (enable)
       {
-        QHostAddress bind_addr {m_config.udp_server_name ()};
-        m_udp_server->start (m_config.udp_server_port (), QHostAddress {}, QSet<QString> {},
-                             bind_addr.isNull () ? QHostAddress {QHostAddress::LocalHost} : bind_addr);
+        m_udp_server->start (m_config.udp_server_port ());
       }
     else
       {
@@ -753,9 +745,7 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
   connect (&m_config, &Configuration::udp_server_port_changed, [this] (Configuration::port_type port) {
     if (m_config.accept_udp_requests ())
       {
-        QHostAddress bind_addr {m_config.udp_server_name ()};
-        m_udp_server->start (port, QHostAddress {}, QSet<QString> {},
-                             bind_addr.isNull () ? QHostAddress {QHostAddress::LocalHost} : bind_addr);
+        m_udp_server->start (port);
       }
   });
 


### PR DESCRIPTION
Reports of broken grid-tracker connectivity 

Seems like some users fix the issue by clearing IP address values or re starting and entering new data switching from 127 to 192 and eventually it works but reverting this code clears up all issues 


See also 

https://github.com/sq9fve/wsjt-z/issues/109