### PR TITLE
Fix signal meter width changing with reading

### DIFF
--- a/widgets/signalmeter.cpp
+++ b/widgets/signalmeter.cpp
@@ -92,6 +92,7 @@ SignalMeter::SignalMeter (QWidget * parent)
 
   m_reading = new QLabel(this);
   m_reading->setAlignment(Qt::AlignCenter);
+  m_reading->setMinimumWidth(QFontMetrics {m_reading->font ()}.horizontalAdvance(QString::number(MAXDB)));
   m_unit = new QLabel(tr("dB"), this);
   m_unit->setAlignment(Qt::AlignCenter);
 


### PR DESCRIPTION
Since the signal meter reading and its dB unit were moved into separate horizontal labels, the meter width changed when the reading switched between one and two digits.

This was visible as the signal bar becoming slightly wider for values such as 70 dB than for 0 dB.
@Jamzed observe this issue on the Ubuntu 26.04.

Fix

Reserve enough minimum width for the numeric label to display the maximum meter value. The reading remains centered and the overall signal meter width no longer changes with the number of digits.