### PR TITLE
sat-mode-logging

### DIFF
--- a/Network/MessageClient.cpp
+++ b/Network/MessageClient.cpp
@@ -658,7 +658,8 @@ void MessageClient::qso_logged (QDateTime time_off, QString const& dx_call, QStr
                                 , QString const& comments, QString const& name, QDateTime time_on
                                 , QString const& operator_call, QString const& my_call
                                 , QString const& my_grid, QString const& exchange_sent
-                                , QString const& exchange_rcvd, QString const& propmode)
+                                , QString const& exchange_rcvd, QString const& propmode
+                                , QString const& satellite, QString const& satmode, QString const& freqRx)
 {
    if (m_->server_port_ && !m_->server_.isNull ())
     {
@@ -667,8 +668,9 @@ void MessageClient::qso_logged (QDateTime time_off, QString const& dx_call, QStr
       out << time_off << dx_call.toUtf8 () << dx_grid.toUtf8 () << dial_frequency << mode.toUtf8 ()
           << report_sent.toUtf8 () << report_received.toUtf8 () << tx_power.toUtf8 () << comments.toUtf8 ()
           << name.toUtf8 () << time_on << operator_call.toUtf8 () << my_call.toUtf8 () << my_grid.toUtf8 ()
-          << exchange_sent.toUtf8 () << exchange_rcvd.toUtf8 () << propmode.toUtf8 ();
-      TRACE_UDP ("time off:" << time_off << "DX:" << dx_call << "DX grid:" << dx_grid << "dial:" << dial_frequency << "mode:" << mode << "sent:" << report_sent << "rcvd:" << report_received << "pwr:" << tx_power << "comments:" << comments << "name:" << name << "time on:" << time_on << "op:" << operator_call << "DE:" << my_call << "DE grid:" << my_grid << "exch sent:" << exchange_sent << "exch rcvd:" << exchange_rcvd  << "prop_mode:" << propmode);
+          << exchange_sent.toUtf8 () << exchange_rcvd.toUtf8 () << propmode.toUtf8 () << satellite.toUtf8 ()
+          << satmode.toUtf8 () << freqRx.toUtf8 ();
+      TRACE_UDP ("time off:" << time_off << "DX:" << dx_call << "DX grid:" << dx_grid << "dial:" << dial_frequency << "mode:" << mode << "sent:" << report_sent << "rcvd:" << report_received << "pwr:" << tx_power << "comments:" << comments << "name:" << name << "time on:" << time_on << "op:" << operator_call << "DE:" << my_call << "DE grid:" << my_grid << "exch sent:" << exchange_sent << "exch rcvd:" << exchange_rcvd  << "prop_mode:" << propmode << "sat_name:" << satellite << "sat_mode:" << satmode << "freq_rx:" << freqRx);
       m_->send_message (out, message);
     }
 }

--- a/Network/MessageClient.hpp
+++ b/Network/MessageClient.hpp
@@ -78,7 +78,8 @@ public:
                           , QString const& name, QDateTime time_on, QString const& operator_call
                           , QString const& my_call, QString const& my_grid
                           , QString const& exchange_sent, QString const& exchange_rcvd
-                          , QString const& propmode);
+                          , QString const& propmode, QString const& satellite
+                          , QString const& satmode, QString const& freqRx);
 
   // ADIF_record argument should be valid ADIF excluding any <EOR> end
   // of record marker

--- a/logbook/logbook.cpp
+++ b/logbook/logbook.cpp
@@ -79,7 +79,8 @@ QByteArray LogBook::QSOToADIF (QString const& hisCall, QString const& hisGrid, Q
                                QDateTime const& dateTimeOff, QString const& band, QString const& comments,
                                QString const& name, QString const& strDialFreq, QString const& myCall,
                                QString const& myGrid, QString const& txPower, QString const& operator_call,
-                               QString const& xSent, QString const& xRcvd, QString const& propmode)
+                               QString const& xSent, QString const& xRcvd, QString const& propmode,
+                               QString const& satellite, QString const& satmode, QString const& freqRx)
 {
   QString t;
   t = "<call:" + QString::number(hisCall.size()) + ">" + hisCall;
@@ -107,6 +108,9 @@ QByteArray LogBook::QSOToADIF (QString const& hisCall, QString const& hisGrid, Q
   if(name!="") t += " <name:" + QString::number(name.size()) + ">" + name;
   if(operator_call!="") t+=" <operator:" + QString::number(operator_call.size()) + ">" + operator_call;
   if(propmode!="") t += " <prop_mode:" + QString::number(propmode.size()) + ">" + propmode;
+  if(satellite!="") t += " <sat_name:" + QString::number(satellite.size()) + ">" + satellite;
+  if(satmode!="") t += " <sat_mode:" + QString::number(satmode.size()) + ">" + satmode;
+  if(freqRx!="") t += " <freq_rx:" + QString::number(freqRx.size()) + ">" + freqRx;
   if (xSent.size ())
     {
       auto words = xSent.split (' '

--- a/logbook/logbook.h
+++ b/logbook/logbook.h
@@ -44,7 +44,8 @@ public:
                         QDateTime const& dateTimeOff, QString const& band, QString const& comments,
                         QString const& name, QString const& strDialFreq, QString const& myCall,
                         QString const& m_myGrid, QString const& m_txPower, QString const& operator_call,
-                        QString const& xSent, QString const& xRcvd, QString const& propmode);
+                        QString const& xSent, QString const& xRcvd, QString const& propmode,
+                        QString const& satellite = QString {}, QString const& satmode = QString {}, QString const& freqRx = QString {});
 
   QString const cty_version() const;
 

--- a/widgets/logqso.cpp
+++ b/widgets/logqso.cpp
@@ -88,6 +88,38 @@ LogQSO::LogQSO(QString const& programTitle, QSettings * settings
 {
   ui->setupUi(this);
   setWindowTitle(programTitle + " - Log QSO");
+  ui->comboBoxSatellite->addItem ("", "");
+  QString sat_file_location;
+  QDir dataPath {QStandardPaths::writableLocation (QStandardPaths::DataLocation)};
+  sat_file_location = dataPath.exists("sat.dat") ? dataPath.absoluteFilePath("sat.dat") : m_config->data_dir ().absoluteFilePath ("sat.dat");
+  QFile file {sat_file_location};
+  QStringList wordList;
+  QTextStream stream(&file);
+  if(file.open (QIODevice::ReadOnly | QIODevice::Text)) {
+      while (!stream.atEnd()) {
+          QString line = stream.readLine();
+          wordList = line.split('|');
+          if(wordList.size() >= 2) {
+              ui->comboBoxSatellite->addItem (wordList[1], wordList[0]);
+          }
+      }
+      stream.flush();
+      file.close();
+  } else {
+      // Fallback to common satellites if sat.dat not found
+      ui->comboBoxSatellite->addItem ("ISS", "ISS");
+      ui->comboBoxSatellite->addItem ("AO-91", "AO-91");
+      ui->comboBoxSatellite->addItem ("AO-92", "AO-92");
+      ui->comboBoxSatellite->addItem ("AO-95", "AO-95");
+      ui->comboBoxSatellite->addItem ("FM-4 (AO-73)", "FM-4");
+      ui->comboBoxSatellite->addItem ("SO-50", "SO-50");
+      ui->comboBoxSatellite->addItem ("RS-44", "RS-44");
+      ui->comboBoxSatellite->addItem ("XW-2A", "XW-2A");
+      ui->comboBoxSatellite->addItem ("XW-2B", "XW-2B");
+      ui->comboBoxSatellite->addItem ("XW-2C", "XW-2C");
+      ui->comboBoxSatellite->addItem ("XW-2D", "XW-2D");
+      ui->comboBoxSatellite->addItem ("XW-2F", "XW-2F");
+  }
   for (auto const& prop_mode : prop_modes)
     {
       ui->comboBoxPropMode->addItem (prop_mode.name_, prop_mode.id_);
@@ -96,36 +128,6 @@ LogQSO::LogQSO(QString const& programTitle, QSettings * settings
     {
       ui->comboBoxSatMode->addItem (sat_mode.name_, sat_mode.id_);
     }
-  // Load satellites from sat.dat file
-  ui->comboBoxSatellite->addItem ("", "");
-  QString sat_file_location;
-  QDir dataPath {QStandardPaths::writableLocation (QStandardPaths::DataLocation)};
-  sat_file_location = dataPath.exists("sat.dat") ? dataPath.absoluteFilePath("sat.dat") : m_config->data_dir ().absoluteFilePath ("sat.dat");
-  QFile file {sat_file_location};
-  QTextStream stream(&file);
-  if(file.open (QIODevice::ReadOnly | QIODevice::Text)) {
-    while(!stream.atEnd()) {
-      QString line = stream.readLine();
-      if(!line.isEmpty()) {
-        ui->comboBoxSatellite->addItem (line, line);
-      }
-    }
-    file.close();
-  } else {
-    // Fallback to common satellites if sat.dat not found
-    ui->comboBoxSatellite->addItem ("ISS", "ISS");
-    ui->comboBoxSatellite->addItem ("AO-91", "AO-91");
-    ui->comboBoxSatellite->addItem ("AO-92", "AO-92");
-    ui->comboBoxSatellite->addItem ("AO-95", "AO-95");
-    ui->comboBoxSatellite->addItem ("FM-4 (AO-73)", "FM-4");
-    ui->comboBoxSatellite->addItem ("SO-50", "SO-50");
-    ui->comboBoxSatellite->addItem ("RS-44", "RS-44");
-    ui->comboBoxSatellite->addItem ("XW-2A", "XW-2A");
-    ui->comboBoxSatellite->addItem ("XW-2B", "XW-2B");
-    ui->comboBoxSatellite->addItem ("XW-2C", "XW-2C");
-    ui->comboBoxSatellite->addItem ("XW-2D", "XW-2D");
-    ui->comboBoxSatellite->addItem ("XW-2F", "XW-2F");
-  }
   loadSettings ();
   connect (ui->comboBoxPropMode, &QComboBox::currentTextChanged, this, &LogQSO::propModeChanged);
   auto date_time_format = QLocale {}.dateFormat (QLocale::ShortFormat) + " hh:mm:ss";
@@ -167,11 +169,14 @@ void LogQSO::loadSettings ()
       satellite = ui->comboBoxSatellite->findData (m_settings->value ("Satellite", "").toString());
     }
   ui->comboBoxSatellite->setCurrentIndex (satellite);
+  if (m_settings->value ("PropMode", "") != "SAT")
+  {
+      ui->cbSatellite->setDisabled(true);
+      ui->comboBoxSatellite->setDisabled(true);
+      ui->cbSatMode->setDisabled(true);
+      ui->comboBoxSatMode->setDisabled(true);
+  }
   m_freqRx = m_settings->value ("FreqRx", "").toString ();
-  if (ui->cbFreqRx->isChecked ())
-    {
-      ui->freqRx->setText (m_freqRx);
-    }
   ui->cbFreqRx->setChecked (m_settings->value ("SaveFreqRx", false).toBool ());
   m_settings->endGroup ();
 }
@@ -252,6 +257,11 @@ void LogQSO::initLogQSO(QString const& hisCall, QString const& hisGrid, QString 
   if (!ui->cbPropMode->isChecked ())
     {
       ui->comboBoxPropMode->setCurrentIndex (-1);
+    }
+  if (!ui->cbSatellite->isChecked ())
+    {
+      ui->comboBoxSatellite->setCurrentIndex (-1);
+      ui->comboBoxSatMode->setCurrentIndex (-1);
     }
   // Restore retained RX frequency if Retain checkbox is checked
   if (ui->cbFreqRx->isChecked ())
@@ -452,14 +462,17 @@ void LogQSO::hideEvent (QHideEvent * e)
 
 void LogQSO::propModeChanged()
 {
-  // Enable/disable satellite controls based on PropMode selection
-  auto propmode = ui->comboBoxPropMode->currentData().toString();
-  bool isSatellite = (propmode == "SAT");
-  
-  // Enable satellite/mode comboboxes and retain checkboxes only when PropMode is "SAT"
-  // But keep RX frequency field always enabled for user input
-  ui->comboBoxSatellite->setEnabled(isSatellite);
-  ui->comboBoxSatMode->setEnabled(isSatellite);
-  ui->cbSatellite->setEnabled(isSatellite);
-  ui->cbSatMode->setEnabled(isSatellite);
+  if (ui->comboBoxPropMode->currentData() != "SAT") {
+      ui->comboBoxSatellite->setCurrentIndex(0);
+      ui->comboBoxSatellite->setDisabled(true);
+      ui->cbSatellite->setDisabled(true);
+      ui->comboBoxSatMode->setCurrentIndex(0);
+      ui->comboBoxSatMode->setDisabled(true);
+      ui->cbSatMode->setDisabled(true);
+  } else {
+      ui->comboBoxSatellite->setDisabled(false);
+      ui->cbSatellite->setDisabled(false);
+      ui->comboBoxSatMode->setDisabled(false);
+      ui->cbSatMode->setDisabled(false);
+  }
 }

--- a/widgets/logqso.cpp
+++ b/widgets/logqso.cpp
@@ -253,16 +253,14 @@ void LogQSO::initLogQSO(QString const& hisCall, QString const& hisGrid, QString 
     {
       ui->comboBoxPropMode->setCurrentIndex (-1);
     }
-  // Auto-populate RX frequency with current TX frequency in MHz
-  QString freqStr = QString::number(dialFreq / 1e6, 'f', 6).trimmed();
-  if (!freqStr.isEmpty() && freqStr != "0")
-    {
-      ui->freqRx->setText(freqStr);
-    }
-  // Override with retained value if Retain checkbox is checked
+  // Restore retained RX frequency if Retain checkbox is checked
   if (ui->cbFreqRx->isChecked ())
     {
       ui->freqRx->setText (m_freqRx);
+    }
+  else
+    {
+      ui->freqRx->clear ();
     }
 
   using SpOp = Configuration::SpecialOperatingActivity;

--- a/widgets/logqso.cpp
+++ b/widgets/logqso.cpp
@@ -5,6 +5,8 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <QDir>
+#include <QFile>
+#include <QTextStream>
 #include <QPushButton>
 
 #include "logbook/logbook.h"
@@ -46,6 +48,34 @@ namespace
      , {"TEP", QT_TRANSLATE_NOOP ("LogQSO", "Trans-equatorial")}
      , {"TR", QT_TRANSLATE_NOOP ("LogQSO", "Troposheric ducting")}
     };
+  struct SatMode
+  {
+    char const * id_;
+    char const * name_;
+  };
+  constexpr SatMode sat_modes[] =
+    {
+      {"", ""}
+      , {"A", QT_TRANSLATE_NOOP ("LogQSO", "A")}
+      , {"B", QT_TRANSLATE_NOOP ("LogQSO", "B")}
+      , {"BS", QT_TRANSLATE_NOOP ("LogQSO", "BS")}
+      , {"JA", QT_TRANSLATE_NOOP ("LogQSO", "JA")}
+      , {"JD", QT_TRANSLATE_NOOP ("LogQSO", "JD")}
+      , {"K", QT_TRANSLATE_NOOP ("LogQSO", "K")}
+      , {"KA", QT_TRANSLATE_NOOP ("LogQSO", "KA")}
+      , {"KT", QT_TRANSLATE_NOOP ("LogQSO", "KT")}
+      , {"L", QT_TRANSLATE_NOOP ("LogQSO", "L")}
+      , {"LS", QT_TRANSLATE_NOOP ("LogQSO", "LS")}
+      , {"LU", QT_TRANSLATE_NOOP ("LogQSO", "LU")}
+      , {"LX", QT_TRANSLATE_NOOP ("LogQSO", "LX")}
+      , {"S", QT_TRANSLATE_NOOP ("LogQSO", "S")}
+      , {"SX", QT_TRANSLATE_NOOP ("LogQSO", "SX")}
+      , {"T", QT_TRANSLATE_NOOP ("LogQSO", "T")}
+      , {"US", QT_TRANSLATE_NOOP ("LogQSO", "US")}
+      , {"UV", QT_TRANSLATE_NOOP ("LogQSO", "UV")}
+      , {"VS", QT_TRANSLATE_NOOP ("LogQSO", "VS")}
+      , {"VU", QT_TRANSLATE_NOOP ("LogQSO", "VU")}
+    };
 }
 
 LogQSO::LogQSO(QString const& programTitle, QSettings * settings
@@ -62,7 +92,42 @@ LogQSO::LogQSO(QString const& programTitle, QSettings * settings
     {
       ui->comboBoxPropMode->addItem (prop_mode.name_, prop_mode.id_);
     }
+  for (auto const& sat_mode : sat_modes)
+    {
+      ui->comboBoxSatMode->addItem (sat_mode.name_, sat_mode.id_);
+    }
+  // Load satellites from sat.dat file
+  ui->comboBoxSatellite->addItem ("", "");
+  QString sat_file_location;
+  QDir dataPath {QStandardPaths::writableLocation (QStandardPaths::DataLocation)};
+  sat_file_location = dataPath.exists("sat.dat") ? dataPath.absoluteFilePath("sat.dat") : m_config->data_dir ().absoluteFilePath ("sat.dat");
+  QFile file {sat_file_location};
+  QTextStream stream(&file);
+  if(file.open (QIODevice::ReadOnly | QIODevice::Text)) {
+    while(!stream.atEnd()) {
+      QString line = stream.readLine();
+      if(!line.isEmpty()) {
+        ui->comboBoxSatellite->addItem (line, line);
+      }
+    }
+    file.close();
+  } else {
+    // Fallback to common satellites if sat.dat not found
+    ui->comboBoxSatellite->addItem ("ISS", "ISS");
+    ui->comboBoxSatellite->addItem ("AO-91", "AO-91");
+    ui->comboBoxSatellite->addItem ("AO-92", "AO-92");
+    ui->comboBoxSatellite->addItem ("AO-95", "AO-95");
+    ui->comboBoxSatellite->addItem ("FM-4 (AO-73)", "FM-4");
+    ui->comboBoxSatellite->addItem ("SO-50", "SO-50");
+    ui->comboBoxSatellite->addItem ("RS-44", "RS-44");
+    ui->comboBoxSatellite->addItem ("XW-2A", "XW-2A");
+    ui->comboBoxSatellite->addItem ("XW-2B", "XW-2B");
+    ui->comboBoxSatellite->addItem ("XW-2C", "XW-2C");
+    ui->comboBoxSatellite->addItem ("XW-2D", "XW-2D");
+    ui->comboBoxSatellite->addItem ("XW-2F", "XW-2F");
+  }
   loadSettings ();
+  connect (ui->comboBoxPropMode, &QComboBox::currentTextChanged, this, &LogQSO::propModeChanged);
   auto date_time_format = QLocale {}.dateFormat (QLocale::ShortFormat) + " hh:mm:ss";
   ui->start_date_time->setDisplayFormat (date_time_format);
   ui->end_date_time->setDisplayFormat (date_time_format);
@@ -80,6 +145,8 @@ void LogQSO::loadSettings ()
   ui->cbTxPower->setChecked (m_settings->value ("SaveTxPower", false).toBool ());
   ui->cbComments->setChecked (m_settings->value ("SaveComments", false).toBool ());
   ui->cbPropMode->setChecked (m_settings->value ("SavePropMode", false).toBool ());
+  ui->cbSatellite->setChecked (m_settings->value ("SaveSatellite", false).toBool ());
+  ui->cbSatMode->setChecked (m_settings->value ("SaveSatMode", false).toBool ());
   m_txPower = m_settings->value ("TxPower", "").toString ();
   m_comments = m_settings->value ("LogComments", "").toString();
   int prop_index {0};
@@ -88,6 +155,24 @@ void LogQSO::loadSettings ()
       prop_index = ui->comboBoxPropMode->findData (m_settings->value ("PropMode", "").toString());
     }
   ui->comboBoxPropMode->setCurrentIndex (prop_index);
+  int sat_mode_index {0};
+  if (ui->cbSatMode->isChecked ())
+    {
+      sat_mode_index = ui->comboBoxSatMode->findData (m_settings->value ("SatMode", "").toString());
+    }
+  ui->comboBoxSatMode->setCurrentIndex (sat_mode_index);
+  int satellite {0};
+  if (ui->cbSatellite->isChecked ())
+    {
+      satellite = ui->comboBoxSatellite->findData (m_settings->value ("Satellite", "").toString());
+    }
+  ui->comboBoxSatellite->setCurrentIndex (satellite);
+  m_freqRx = m_settings->value ("FreqRx", "").toString ();
+  if (ui->cbFreqRx->isChecked ())
+    {
+      ui->freqRx->setText (m_freqRx);
+    }
+  ui->cbFreqRx->setChecked (m_settings->value ("SaveFreqRx", false).toBool ());
   m_settings->endGroup ();
 }
 
@@ -98,9 +183,15 @@ void LogQSO::storeSettings () const
   m_settings->setValue ("SaveTxPower", ui->cbTxPower->isChecked ());
   m_settings->setValue ("SaveComments", ui->cbComments->isChecked ());
   m_settings->setValue ("SavePropMode", ui->cbPropMode->isChecked ());
+  m_settings->setValue ("SaveSatellite", ui->cbSatellite->isChecked ());
+  m_settings->setValue ("SaveSatMode", ui->cbSatMode->isChecked ());
+  m_settings->setValue ("SaveFreqRx", ui->cbFreqRx->isChecked ());
   m_settings->setValue ("TxPower", m_txPower);
   m_settings->setValue ("LogComments", m_comments);
   m_settings->setValue ("PropMode", ui->comboBoxPropMode->currentData ());
+  m_settings->setValue ("SatMode", ui->comboBoxSatMode->currentData ());
+  m_settings->setValue ("Satellite", ui->comboBoxSatellite->currentData ());
+  m_settings->setValue ("FreqRx", m_freqRx);
   m_settings->endGroup ();
 }
 
@@ -161,6 +252,17 @@ void LogQSO::initLogQSO(QString const& hisCall, QString const& hisGrid, QString 
   if (!ui->cbPropMode->isChecked ())
     {
       ui->comboBoxPropMode->setCurrentIndex (-1);
+    }
+  // Auto-populate RX frequency with current TX frequency in MHz
+  QString freqStr = QString::number(dialFreq / 1e6, 'f', 6).trimmed();
+  if (!freqStr.isEmpty() && freqStr != "0")
+    {
+      ui->freqRx->setText(freqStr);
+    }
+  // Override with retained value if Retain checkbox is checked
+  if (ui->cbFreqRx->isChecked ())
+    {
+      ui->freqRx->setText (m_freqRx);
     }
 
   using SpOp = Configuration::SpecialOperatingActivity;
@@ -263,6 +365,14 @@ void LogQSO::accept()
     }
 
   auto const& prop_mode = ui->comboBoxPropMode->currentData ().toString ();
+  auto satellite = ui->comboBoxSatellite->currentData ().toString ();
+  auto sat_mode = ui->comboBoxSatMode->currentData ().toString ();
+  if (prop_mode != "SAT") {
+    satellite = "";
+    sat_mode = "";
+  }
+  m_freqRx = ui->freqRx->text ();
+  
   //Log this QSO to file "wsjtx.log"
   static QFile f {QDir {QStandardPaths::writableLocation (QStandardPaths::DataLocation)}.absoluteFilePath ("wsjtx.log")};
   if(!f.open(QIODevice::Text | QIODevice::Append)) {
@@ -306,6 +416,9 @@ void LogQSO::accept()
                     , xsent
                     , xrcvd
                     , prop_mode
+                    , satellite
+                    , sat_mode
+                    , m_freqRx
                     , m_log->QSOToADIF (hisCall
                                         , hisGrid
                                         , mode
@@ -323,7 +436,10 @@ void LogQSO::accept()
                                         , operator_call
                                         , xsent
                                         , xrcvd
-                                        , prop_mode));
+                                        , prop_mode
+                                        , satellite
+                                        , sat_mode
+                                        , m_freqRx));
   QDialog::accept();
 }
 
@@ -334,4 +450,18 @@ void LogQSO::hideEvent (QHideEvent * e)
 {
   storeSettings ();
   QDialog::hideEvent (e);
+}
+
+void LogQSO::propModeChanged()
+{
+  // Enable/disable satellite controls based on PropMode selection
+  auto propmode = ui->comboBoxPropMode->currentData().toString();
+  bool isSatellite = (propmode == "SAT");
+  
+  // Enable satellite/mode comboboxes and retain checkboxes only when PropMode is "SAT"
+  // But keep RX frequency field always enabled for user input
+  ui->comboBoxSatellite->setEnabled(isSatellite);
+  ui->comboBoxSatMode->setEnabled(isSatellite);
+  ui->cbSatellite->setEnabled(isSatellite);
+  ui->cbSatMode->setEnabled(isSatellite);
 }

--- a/widgets/logqso.h
+++ b/widgets/logqso.h
@@ -42,7 +42,8 @@ signals:
                   , QString const& name, QDateTime const& QSO_date_on,  QString const& operator_call
                   , QString const& my_call, QString const& my_grid
                   , QString const& exchange_sent, QString const& exchange_rcvd
-                  , QString const& propmode, QByteArray const& ADIF);
+                  , QString const& propmode, QString const& satellite
+                  , QString const& sat_mode, QString const& freqRx, QByteArray const& ADIF);
 
 protected:
   void hideEvent (QHideEvent *);
@@ -50,6 +51,7 @@ protected:
 private:
   void loadSettings ();
   void storeSettings () const;
+  void propModeChanged ();
 
   QScopedPointer<Ui::LogQSO> ui;
   QSettings * m_settings;
@@ -60,6 +62,7 @@ private:
   Radio::Frequency m_dialFreq;
   QString m_myCall;
   QString m_myGrid;
+  QString m_freqRx;
 };
 
 #endif // LogQSO_H

--- a/widgets/logqso.ui
+++ b/widgets/logqso.ui
@@ -514,6 +514,85 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0,0,0">
+     <item>
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Satellite</string>
+       </property>
+       <property name="buddy">
+        <cstring>comboBoxSatellite</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBoxSatellite">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbSatellite">
+       <property name="text">
+        <string>Retain</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,0,0">
+     <item>
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Sat Mode</string>
+       </property>
+       <property name="buddy">
+        <cstring>comboBoxSatMode</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBoxSatMode"/>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbSatMode">
+       <property name="text">
+        <string>Retain</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,0,0">
+     <item>
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>RX Freq</string>
+       </property>
+       <property name="buddy">
+        <cstring>freqRx</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="freqRx"/>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbFreqRx">
+       <property name="text">
+        <string>Retain</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -557,6 +636,12 @@
   <tabstop>exchRcvd</tabstop>
   <tabstop>comboBoxPropMode</tabstop>
   <tabstop>cbPropMode</tabstop>
+  <tabstop>comboBoxSatellite</tabstop>
+  <tabstop>cbSatellite</tabstop>
+  <tabstop>comboBoxSatMode</tabstop>
+  <tabstop>cbSatMode</tabstop>
+  <tabstop>freqRx</tabstop>
+  <tabstop>cbFreqRx</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -9169,7 +9169,8 @@ void MainWindow::acceptQSO (QDateTime const& QSO_date_off, QString const& call, 
                             , QString const& name, QDateTime const& QSO_date_on, QString const& operator_call
                             , QString const& my_call, QString const& my_grid
                             , QString const& exchange_sent, QString const& exchange_rcvd
-                            , QString const& propmode, QByteArray const& ADIF)
+                            , QString const& propmode, QString const& satellite
+                            , QString const& satmode, QString const& freqRx, QByteArray const& ADIF)
 {
   QString date = QSO_date_on.toString("yyyyMMdd");
   if (!m_logBook.add (call, grid, m_config.bands()->find(dial_freq), mode, ADIF))
@@ -9180,7 +9181,7 @@ void MainWindow::acceptQSO (QDateTime const& QSO_date_off, QString const& call, 
 
   m_messageClient->qso_logged (QSO_date_off, call, grid, dial_freq, mode, rpt_sent, rpt_received
                                , tx_power, comments, name, QSO_date_on, operator_call, my_call, my_grid
-                               , exchange_sent, exchange_rcvd, propmode);
+                               , exchange_sent, exchange_rcvd, propmode, satellite, satmode, freqRx);
   m_messageClient->logged_ADIF (ADIF);
 
   // Z

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -279,7 +279,8 @@ private slots:
                   , QString const& name, QDateTime const& QSO_date_on, QString const& operator_call
                   , QString const& my_call, QString const& my_grid
                   , QString const& exchange_sent, QString const& exchange_rcvd
-                  , QString const& propmode, QByteArray const& ADIF);
+                  , QString const& propmode, QString const& satellite
+                  , QString const& satmode, QString const& freqRx, QByteArray const& ADIF);
   void on_bandComboBox_currentIndexChanged (int index);
   void on_bandComboBox_editTextChanged (QString const& text);
   void on_bandComboBox_activated (int index);


### PR DESCRIPTION
functional for satellite QSO logging with Log4OM! The RX frequency and satellite mode info will be transmitted in the ADIF data

Implemented sat.dat file loading:

Looks for sat.dat in ~/.local/share/WSJT-X/ or config data directory Loads custom satellite list from file (one satellite name per line) Falls back to hardcoded common satellites if file not found Allows users to maintain their own satellite list externally