### PR TITLE
stale-dx

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -15433,6 +15433,7 @@ void MainWindow::ZProcess ()
         tx_watchdog(false);
         if (m_zdebug) log("Next call: " + m_priorityCall);
         m_nextCall = m_priorityCall;
+        if (ui->cbAutoCall->isChecked()) ui->dxCallEntry->setText("");
         m_nextGrid = m_prioGrid;
         dxLookup(m_nextCall, m_prioGrid);
         ui->rptSpinBox->setValue(m_nextRpt.toInt());


### PR DESCRIPTION
clears the stale DX call entry after entering a new QSO in AutoCall mode. This prevents the gate condition from blocking frequency snapping on subsequent QSOs.