### PR TITLE
fix-erase-right-click

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -6401,15 +6401,9 @@ void MainWindow::on_EraseButton_clicked ()
   }
 
   if (m_nEraseClicks >= 3) {
+    clearDX();
+    ui->tx5->clearEditText();  // match triple-click behavior
     ui->stopTxButton->click (); // halt any transmission
-    ui->tx1->clear();
-    ui->tx2->clear();
-    ui->tx3->clear();
-    ui->tx4->clear();
-    ui->tx5->clearEditText();
-    ui->dxCallEntry->clear();
-    ui->dxGridEntry->clear();
-    ui->txrb6->setChecked(true);
     if (m_zdebug) log("Auto-sequencing stopped by triple Erase click");
     m_nEraseClicks = 0;
   }

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -3450,14 +3450,8 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
       if (object == ui->EraseButton) {
         auto const *mouseEvent = static_cast<QMouseEvent const *> (event);
         if (mouseEvent->button() == Qt::RightButton) {
-          ui->tx1->clear();
-          ui->tx2->clear();
-          ui->tx3->clear();
-          ui->tx4->clear();
-          ui->tx5->clearEditText();
-          ui->dxCallEntry->clear();
-          ui->dxGridEntry->clear();
-          ui->txrb6->setChecked(true);
+          clearDX();
+          ui->tx5->clearEditText();  // match triple-click behavior
           if (ui->cbAutoCall->isChecked()) {
             ui->stopTxButton->click (); // halt any transmission
             if (m_zdebug) log("Tx stopped by right-click on Erase button");


### PR DESCRIPTION
Right-click erase 3× with the same DX call should now allow TX5 to populate on the next decode, matching the triple-click behavior.