### PR TITLE
resetLOGutc

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -864,10 +864,10 @@ Configuration::Configuration (QNetworkAccessManager * network_manager, QDir cons
 
 void Configuration::rescan_logbook ()
 {
-  auto * impl = m_.operator-> ();
-  if (impl && impl->logbook_)
+  auto * impl_ptr = m_.operator-> ();
+  if (impl_ptr && impl_ptr->logbook_)
     {
-      impl->logbook_->rescan ();
+      impl_ptr->logbook_->rescan ();
     }
 }
 

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -862,6 +862,15 @@ Configuration::Configuration (QNetworkAccessManager * network_manager, QDir cons
 {
 }
 
+void Configuration::rescan_logbook ()
+{
+  auto * impl = m_.operator-> ();
+  if (impl && impl->logbook_)
+    {
+      impl->logbook_->rescan ();
+    }
+}
+
 Configuration::~Configuration ()
 {
 }
@@ -2990,9 +2999,7 @@ void Configuration::impl::on_reset_highlighting_to_defaults_push_button_clicked 
 
 void Configuration::impl::on_rescan_log_push_button_clicked (bool /*clicked*/)
 {
-  if (logbook_) {
-    logbook_->rescan ();
-  }
+  self_->rescan_logbook ();
 }
 
 void Configuration::impl::on_CTY_download_button_clicked (bool /*clicked*/)
@@ -3025,7 +3032,7 @@ void Configuration::impl::after_CTY_downloaded ()
 {
   ui_->CTY_download_button->setEnabled (true);
   if (logbook_) {
-    logbook_->rescan ();
+    self_->rescan_logbook ();
     ui_->CTY_file_label->setText(QString{"CTY File Version: %1"}.arg(logbook_->cty_version()));
   }
 }

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -303,6 +303,7 @@ public:
   void transceiver_offline ();
 
   void set_CTY_DAT_version(QString const& version);
+  void rescan_logbook();
 
   // Set transceiver frequency in Hertz.
   Q_SLOT void transceiver_frequency (Frequency);

--- a/Network/MessageClient.cpp
+++ b/Network/MessageClient.cpp
@@ -401,6 +401,17 @@ void MessageClient::impl::parse_message (QByteArray const& msg)
               }
               break;
 
+            case NetworkMessage::RotateLog:
+              {
+                auto status = check_status (in);
+                TRACE_UDP ("RotateLog check_status result:" << status);
+                if (status != Fail)
+                  {
+                    Q_EMIT self_->rotate_log ();
+                  }
+              }
+              break;
+
               case NetworkMessage::AnnotationInfo: {
                 QByteArray dx_call;
                 bool sort_order_provided{false};

--- a/Network/MessageClient.hpp
+++ b/Network/MessageClient.hpp
@@ -123,6 +123,9 @@ public:
                            , bool fast_mode, quint32 tr_period, quint32 rx_df, QString const& dx_call
                            , QString const& dx_grid, bool generate_messages, bool auto_cq_enabled, bool auto_call_enabled);
 
+  // this signal is emitted if the server has requested an ADIF log rotation
+  Q_SIGNAL void rotate_log ();
+
   // this signal is emitted if the server has sent information about a callsign
   Q_SIGNAL void annotation_info (QString const& dx_call, bool sort_order_provided, quint32 sort_order);
 

--- a/Network/NetworkMessage.hpp
+++ b/Network/NetworkMessage.hpp
@@ -567,6 +567,7 @@ namespace NetworkMessage
       HighlightCallsign,
       SwitchConfiguration,
       Configure,
+      RotateLog,
       AnnotationInfo,
       maximum_message_type_     // ONLY add new message types
                                 // immediately before here

--- a/Network/NetworkMessage.hpp
+++ b/Network/NetworkMessage.hpp
@@ -536,6 +536,12 @@
  *      ffffffff will remove the sort-order value from the internal table.
  *      Callsigns without a sort order will be valued at zero for sorting purposes
  *      in the hound display.
+ *
+ * RotateLog         In     17
+ *
+ *      Instructs WSJT-X to rotate the ADIF log: rename wsjtx_log.adi to a
+ *      timestamped backup and start a new wsjtx_log.adi file. This message
+ *      carries no payload.
  */
 
 #include <QDataStream>

--- a/Network/NetworkMessage.hpp
+++ b/Network/NetworkMessage.hpp
@@ -567,8 +567,8 @@ namespace NetworkMessage
       HighlightCallsign,
       SwitchConfiguration,
       Configure,
-      RotateLog,
       AnnotationInfo,
+      RotateLog,
       maximum_message_type_     // ONLY add new message types
                                 // immediately before here
     };

--- a/UDPExamples/MessageServer.cpp
+++ b/UDPExamples/MessageServer.cpp
@@ -397,6 +397,15 @@ void MessageServer::impl::parse_message (QHostAddress const& sender, port_type s
               }
               break;
 
+            case NetworkMessage::RotateLog:
+              {
+                if (check_status (in) != Fail)
+                  {
+                    Q_EMIT self_->rotate_log (client_key);
+                  }
+              }
+              break;
+
             default:
               // Ignore
               break;

--- a/UDPExamples/MessageServer.hpp
+++ b/UDPExamples/MessageServer.hpp
@@ -123,6 +123,9 @@ public:
                                   , QString const& dx_call, QString const& dx_grid, bool generate_messages
                                   , bool auto_cq_enabled, bool auto_call_enabled);
 
+  // Signal emitted when a RotateLog message is received from a remote client
+  Q_SIGNAL void rotate_log (ClientKey const&);
+
   // this signal is emitted when a network error occurs
   Q_SIGNAL void error (QString const&) const;
 

--- a/UDPExamples/control_WSJT-UDP.py
+++ b/UDPExamples/control_WSJT-UDP.py
@@ -15,7 +15,8 @@ from datetime import datetime
 class MessageType(IntEnum):
     """WSJT-Z UDP Message Types"""
     Configure = 15
-    RotateLog = 16
+    AnnotationInfo = 16
+    RotateLog = 17
 
 
 class QtDataStreamWriter:

--- a/UDPExamples/control_WSJT-UDP.py
+++ b/UDPExamples/control_WSJT-UDP.py
@@ -15,6 +15,7 @@ from datetime import datetime
 class MessageType(IntEnum):
     """WSJT-Z UDP Message Types"""
     Configure = 15
+    RotateLog = 16
 
 
 class QtDataStreamWriter:
@@ -137,6 +138,16 @@ def build_configure(message_id, mode='', frequency_tolerance=0xffffffff,
     return writer.get_bytes()
 
 
+def build_rotate_log(message_id, schema=3):
+    """Build RotateLog message"""
+    writer = QtDataStreamWriter()
+    writer.write_uint32(0xadbccbda)  # magic
+    writer.write_uint32(schema)
+    writer.write_uint32(MessageType.RotateLog)
+    writer.write_utf8(message_id)
+    return writer.get_bytes()
+
+
 
 
 
@@ -208,7 +219,28 @@ def cmd_configure(args):
         return 1
 
 
+def cmd_rotate_log(args):
+    """Handle 'rotate-log' subcommand"""
+    message = build_rotate_log(args.id, schema=args.schema)
 
+    if args.verbose:
+        print("=" * 60)
+        print("Rotate Log Message")
+        print("=" * 60)
+        print(f"Target: {args.host}:{args.port}")
+        print(f"Client ID: {args.id}")
+        print(f"Schema: {args.schema}")
+        print()
+
+    if send_udp_message(args.host, args.port, message):
+        if args.verbose:
+            print("✓ Message sent successfully")
+        else:
+            print("OK")
+        return 0
+    else:
+        print("✗ Failed to send message", file=sys.stderr)
+        return 1
 
 
 # ============================================================================
@@ -272,6 +304,11 @@ Examples:
     config_parser.add_argument('--schema', type=int, choices=[2, 3],
                               help='Schema version (default: auto-detect)')
     config_parser.set_defaults(func=cmd_configure, auto_cq=None, auto_call=None)
+
+    rotate_parser = subparsers.add_parser('rotate-log', help='Rotate the ADIF log file')
+    rotate_parser.add_argument('--schema', type=int, choices=[3], default=3,
+                              help='Schema version (default: 3)')
+    rotate_parser.set_defaults(func=cmd_rotate_log)
     
     args = parser.parse_args()
     

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -10481,12 +10481,33 @@ void MainWindow::rotate_wsjtx_log_adi(bool confirm)
           return;
         }
     }
+  else
+    {
+      // Rate limit remote rotations to prevent DoS via repeated UDP datagrams
+      auto now = QDateTime::currentDateTimeUtc ();
+      if (m_lastRotateLogUtc.isValid () && m_lastRotateLogUtc.secsTo (now) < 5)
+        {
+          if (m_zdebug)
+            {
+              log (tr ("Rotate: Rate limited, ignoring rotation request within 5 seconds"));
+            }
+          return;
+        }
+      m_lastRotateLogUtc = now;
+    }
 
   QDir log_dir = m_config.writeable_data_dir ();
   QFileInfo current_log {log_dir.absoluteFilePath ("wsjtx_log.adi")};
   if (!current_log.exists ())
     {
-      MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("No wsjtx_log.adi file exists to rotate."));
+      if (confirm)
+        {
+          MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("No wsjtx_log.adi file exists to rotate."));
+        }
+      else if (m_zdebug)
+        {
+          log (tr ("Rotate: No wsjtx_log.adi file exists to rotate."));
+        }
       return;
     }
 
@@ -10494,27 +10515,43 @@ void MainWindow::rotate_wsjtx_log_adi(bool confirm)
   QString rotated_name = QString {"wsjtx_log_%1.adi"}.arg (timestamp);
   QString rotated_path = log_dir.absoluteFilePath (rotated_name);
 
-  if (QFile::exists (rotated_path))
+  // Handle duplicate filenames from rapid successive rotations (1s granularity)
+  for (int suffix = 1; QFile::exists (rotated_path); ++suffix)
     {
-      QFile::remove (rotated_path);
+      rotated_name = QString {"wsjtx_log_%1_%2.adi"}.arg (timestamp).arg (suffix);
+      rotated_path = log_dir.absoluteFilePath (rotated_name);
     }
 
   if (!QFile::rename (current_log.absoluteFilePath (), rotated_path))
     {
-      MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("Failed to rotate the current ADIF log file."));
+      if (confirm)
+        {
+          MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("Failed to rotate the current ADIF log file."));
+        }
+      else if (m_zdebug)
+        {
+          log (tr ("Rotate: Failed to rotate the current ADIF log file."));
+        }
       return;
     }
 
   QFile new_log {log_dir.absoluteFilePath ("wsjtx_log.adi")};
   if (!new_log.open (QIODevice::WriteOnly | QIODevice::Text))
     {
-      MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("Failed to create a new ADIF log file."));
+      if (confirm)
+        {
+          MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("Failed to create a new ADIF log file."));
+        }
+      else if (m_zdebug)
+        {
+          log (tr ("Rotate: Failed to create a new ADIF log file."));
+        }
       return;
     }
 
   QTextStream out {&new_log};
   auto const created_timestamp = QDateTime::currentDateTimeUtc ().toString ("yyyyMMdd HHmmss");
-  auto const ver = QApplication::applicationVersion ();
+  auto const ver = version (true);
   out << "ADIF Export\n"
       << "<adif_ver:5>3.1.1\n"
       << "<created_timestamp:15>" << created_timestamp << "\n"

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -715,7 +715,9 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
   connect (m_messageClient, &MessageClient::highlight_callsign, ui->decodedTextBrowser, &DisplayText::highlight_callsign);
   connect (m_messageClient, &MessageClient::switch_configuration, m_multi_settings, &MultiSettings::select_configuration);
   connect (m_messageClient, &MessageClient::configure, this, &MainWindow::remote_configure);
-  connect (m_messageClient, &MessageClient::rotate_log, this, &MainWindow::on_actionRotate_wsjtx_log_adi_triggered);
+  connect (m_messageClient, &MessageClient::rotate_log, this, [this] () {
+    this->rotate_wsjtx_log_adi (false);
+  });
 
   // Set up MessageServer to listen for incoming UDP messages on port 2237
   // This allows remote clients to send Configure and other commands to WSJT-X
@@ -10512,11 +10514,12 @@ void MainWindow::rotate_wsjtx_log_adi(bool confirm)
 
   QTextStream out {&new_log};
   auto const created_timestamp = QDateTime::currentDateTimeUtc ().toString ("yyyyMMdd HHmmss");
+  auto const ver = QApplication::applicationVersion ();
   out << "ADIF Export\n"
       << "<adif_ver:5>3.1.1\n"
       << "<created_timestamp:15>" << created_timestamp << "\n"
       << "<programid:6>WSJT-X\n"
-      << "<programversion:5>" << QApplication::applicationVersion ().left (5) << "\n"
+      << QString {"<programversion:%1>%2\n"}.arg (ver.size ()).arg (ver)
       << "<eoh>" << Qt::endl;
   new_log.close ();
 

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -715,12 +715,16 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
   connect (m_messageClient, &MessageClient::highlight_callsign, ui->decodedTextBrowser, &DisplayText::highlight_callsign);
   connect (m_messageClient, &MessageClient::switch_configuration, m_multi_settings, &MultiSettings::select_configuration);
   connect (m_messageClient, &MessageClient::configure, this, &MainWindow::remote_configure);
+  connect (m_messageClient, &MessageClient::rotate_log, this, &MainWindow::on_actionRotate_wsjtx_log_adi_triggered);
 
   // Set up MessageServer to listen for incoming UDP messages on port 2237
   // This allows remote clients to send Configure and other commands to WSJT-X
   m_udp_server = new MessageServer {this, QApplication::applicationName (), version ()};
   connect (m_udp_server, &MessageServer::remote_configure, this, [this] (MessageServer::ClientKey const&, QString const& mode, quint32 frequency_tolerance, QString const& submode, bool fast_mode, quint32 tr_period, quint32 rx_df, QString const& dx_call, QString const& dx_grid, bool generate_messages, bool auto_cq_enabled, bool auto_call_enabled) {
     this->remote_configure (mode, frequency_tolerance, submode, fast_mode, tr_period, rx_df, dx_call, dx_grid, generate_messages, auto_cq_enabled, auto_call_enabled);
+  });
+  connect (m_udp_server, &MessageServer::rotate_log, this, [this] (MessageServer::ClientKey const&) {
+    this->rotate_wsjtx_log_adi (false);
   });
   
   // Only start listening if accept_udp_requests is enabled
@@ -10464,13 +10468,16 @@ void MainWindow::on_actionErase_wsjtx_log_adi_triggered()
   }
 }
 
-void MainWindow::on_actionRotate_wsjtx_log_adi_triggered()
+void MainWindow::rotate_wsjtx_log_adi(bool confirm)
 {
-  int ret = MessageBox::query_message (this, tr ("Confirm Rotate"),
-                                       tr ("Rotate the current wsjtx_log.adi file to a timestamped backup and start a new log?"));
-  if (ret != MessageBox::Yes)
+  if (confirm)
     {
-      return;
+      int ret = MessageBox::query_message (this, tr ("Confirm Rotate"),
+                                           tr ("Rotate the current wsjtx_log.adi file to a timestamped backup and start a new log?"));
+      if (ret != MessageBox::Yes)
+        {
+          return;
+        }
     }
 
   QDir log_dir = m_config.writeable_data_dir ();
@@ -10517,6 +10524,11 @@ void MainWindow::on_actionRotate_wsjtx_log_adi_triggered()
   qso_total = 0;
   updateQsoCounter (false);
   m_config.rescan_logbook ();
+}
+
+void MainWindow::on_actionRotate_wsjtx_log_adi_triggered()
+{
+  rotate_wsjtx_log_adi (true);
 }
 
 void MainWindow::on_actionErase_WSPR_hashtable_triggered()

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -10464,6 +10464,61 @@ void MainWindow::on_actionErase_wsjtx_log_adi_triggered()
   }
 }
 
+void MainWindow::on_actionRotate_wsjtx_log_adi_triggered()
+{
+  int ret = MessageBox::query_message (this, tr ("Confirm Rotate"),
+                                       tr ("Rotate the current wsjtx_log.adi file to a timestamped backup and start a new log?"));
+  if (ret != MessageBox::Yes)
+    {
+      return;
+    }
+
+  QDir log_dir = m_config.writeable_data_dir ();
+  QFileInfo current_log {log_dir.absoluteFilePath ("wsjtx_log.adi")};
+  if (!current_log.exists ())
+    {
+      MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("No wsjtx_log.adi file exists to rotate."));
+      return;
+    }
+
+  QString timestamp = QDateTime::currentDateTimeUtc ().toString ("yyyyMMddTHHmmssZ");
+  QString rotated_name = QString {"wsjtx_log_%1.adi"}.arg (timestamp);
+  QString rotated_path = log_dir.absoluteFilePath (rotated_name);
+
+  if (QFile::exists (rotated_path))
+    {
+      QFile::remove (rotated_path);
+    }
+
+  if (!QFile::rename (current_log.absoluteFilePath (), rotated_path))
+    {
+      MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("Failed to rotate the current ADIF log file."));
+      return;
+    }
+
+  QFile new_log {log_dir.absoluteFilePath ("wsjtx_log.adi")};
+  if (!new_log.open (QIODevice::WriteOnly | QIODevice::Text))
+    {
+      MessageBox::warning_message (this, tr ("Rotate ADIF Log"), tr ("Failed to create a new ADIF log file."));
+      return;
+    }
+
+  QTextStream out {&new_log};
+  auto const created_timestamp = QDateTime::currentDateTimeUtc ().toString ("yyyyMMdd HHmmss");
+  out << "ADIF Export\n"
+      << "<adif_ver:5>3.1.1\n"
+      << "<created_timestamp:15>" << created_timestamp << "\n"
+      << "<programid:6>WSJT-X\n"
+      << "<programversion:5>" << QApplication::applicationVersion ().left (5) << "\n"
+      << "<eoh>" << Qt::endl;
+  new_log.close ();
+
+  qso_new = 0;
+  qso_total = 0;
+  updateQsoCounter (false);
+  m_config.rescan_logbook ();
+}
+
 void MainWindow::on_actionErase_WSPR_hashtable_triggered()
 {
   int ret = MessageBox::query_message(this, tr ("Confirm Erase"),

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -773,6 +773,7 @@ private:
   QThread * m_pskReporterThread;
   QDateTime m_ignoreListReset;
   QDateTime m_watchdogAnchorUtc;
+  QDateTime m_lastRotateLogUtc;
   qint64 m_msTxFirst;
   bool m_TxFirstLock = false;
   bool m_savedAutoCQfiltering = false;

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -260,6 +260,7 @@ private slots:
   void on_actionErase_ALL_TXT_triggered();
   void on_reset_cabrillo_log_action_triggered ();
   void on_actionErase_wsjtx_log_adi_triggered();
+  void on_actionRotate_wsjtx_log_adi_triggered();
   void on_actionErase_WSPR_hashtable_triggered();
   void on_actionErase_list_of_Q65_callers_triggered();
   void on_actionExport_Cabrillo_log_triggered();

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -261,6 +261,7 @@ private slots:
   void on_reset_cabrillo_log_action_triggered ();
   void on_actionErase_wsjtx_log_adi_triggered();
   void on_actionRotate_wsjtx_log_adi_triggered();
+  void rotate_wsjtx_log_adi(bool confirm = true);
   void on_actionErase_WSPR_hashtable_triggered();
   void on_actionErase_list_of_Q65_callers_triggered();
   void on_actionExport_Cabrillo_log_triggered();

--- a/widgets/mainwindow.ui
+++ b/widgets/mainwindow.ui
@@ -4774,6 +4774,7 @@ list. The list can be maintained in Settings (F2).</string>
     <addaction name="actionDelete_all_wav_files_in_SaveDir"/>
     <addaction name="actionErase_ALL_TXT"/>
     <addaction name="actionErase_wsjtx_log_adi"/>
+    <addaction name="actionRotate_wsjtx_log_adi"/>
     <addaction name="actionErase_WSPR_hashtable"/>
     <addaction name="reset_cabrillo_log_action"/>
     <addaction name="actionExport_Cabrillo_log"/>
@@ -5197,6 +5198,11 @@ list. The list can be maintained in Settings (F2).</string>
   <action name="actionErase_wsjtx_log_adi">
    <property name="text">
     <string>Erase wsjtx_log.adi</string>
+   </property>
+  </action>
+  <action name="actionRotate_wsjtx_log_adi">
+   <property name="text">
+    <string>Rotate _log.adi</string>
    </property>
   </action>
   <action name="actionJT65">

--- a/widgets/mainwindow.ui
+++ b/widgets/mainwindow.ui
@@ -5202,7 +5202,7 @@ list. The list can be maintained in Settings (F2).</string>
   </action>
   <action name="actionRotate_wsjtx_log_adi">
    <property name="text">
-    <string>Rotate _log.adi</string>
+    <string>Rotate wsjtx_log.adi</string>
    </property>
   </action>
   <action name="actionJT65">


### PR DESCRIPTION
The new File-menu action is now wired in and will:

show up as “Rotate _log.adi” under the File menu rename the current ADIF log to a UTC-timestamped backup such as wsjtx_log_20260802T123456Z.adi create a fresh wsjtx_log.adi file
reset the QSO counter display to 0 / 0
trigger the shared logbook rescan path so the worked-before data is refreshed

also adds function to the UDP control to allow rotate via scripts