### PR TITLE
refactor ignore station

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -6235,9 +6235,15 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
       return;
     }
 
+    // Exempt current or last QSO partner from ignore list: even if they're ignored,
+    // we must process their closing messages (73/RR73) to properly advance m_QSOProgress
+    // and log the QSO. Without this exemption, ignoring a station mid-QSO leaves it
+    // unlogged. This mirrors the exemption in callsignFiltered() at line ~14086-14089.
+    bool is_current_qso_partner = (m_lastCall == hiscall || m_hisCall == hiscall);
+
     if (!m_filterCacheValid) rebuildFilterCache();
-    if (m_ignoredStationsCache.contains(hiscall)
-        || m_ignoredStationsCache.contains(Radio::base_callsign(hiscall))) {
+    if (!is_current_qso_partner && (m_ignoredStationsCache.contains(hiscall)
+        || m_ignoredStationsCache.contains(Radio::base_callsign(hiscall)))) {
       return;
     }
 
@@ -12306,6 +12312,7 @@ void MainWindow::tx_watchdog (bool triggered)
                                    && !his_base.isEmpty ()
                                    && candidate_base == his_base;
           bool const target_uncertain = his_base.isEmpty () || candidate_base.isEmpty ();
+          if (!m_filterCacheValid) rebuildFilterCache();
           bool const already_ignored = m_ignoredStationsCache.contains (ignore_candidate)
                                        || m_ignoredStationsCache.contains (candidate_base);
 
@@ -13993,8 +14000,8 @@ void MainWindow::on_btn_addToIgnore_clicked( ) {
 
 void MainWindow::on_btn_clearIgnore_clicked( ) {
     ui->pte_IgnoredStations->clear();
-    ui->pte_IgnoredStations->appendPlainText(m_config.permIgnoreList());
     m_ignoreListReset = QDateTime::currentDateTime();
+    m_filterCacheValid = false;
 }
 
 
@@ -14003,7 +14010,12 @@ void MainWindow::rebuildFilterCache() const
     // Split on '\n' after stripping '\r'; faster than QRegExp("[\r\n]")
     auto split_lines = [](QString s) {
         s.remove(QChar('\r'));
-        return s.split(QChar('\n'), SkipEmptyParts);
+        auto lines = s.split(QChar('\n'), SkipEmptyParts);
+        // Normalize case and whitespace for consistent matching with Radio::base_callsign()
+        for (auto& line : lines) {
+            line = line.trimmed().toUpper();
+        }
+        return lines;
     };
 
     QString combined_ignored = ui->pte_IgnoredStations->toPlainText();

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -6231,6 +6231,11 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
       return;
     }
 
+    if (m_ignoredStationsCache.contains(hiscall)
+        || m_ignoredStationsCache.contains(Radio::base_callsign(hiscall))) {
+      return;
+    }
+
     // Z TODO: This is inccorect - fix !m_config.superFox() && (SpecOp::HOUND != m_specOp)
     bool const auto_qrm_guard_state = m_QSOProgress == CALLING
                       || m_QSOProgress == REPLYING
@@ -13995,7 +14000,14 @@ void MainWindow::rebuildFilterCache() const
         s.remove(QChar('\r'));
         return s.split(QChar('\n'), SkipEmptyParts);
     };
-    m_ignoredStationsCache    = split_lines(ui->pte_IgnoredStations->toPlainText());
+
+    QString combined_ignored = ui->pte_IgnoredStations->toPlainText();
+    if (!m_config.permIgnoreList().isEmpty()) {
+        if (!combined_ignored.isEmpty()) combined_ignored += '\n';
+        combined_ignored += m_config.permIgnoreList();
+    }
+
+    m_ignoredStationsCache    = split_lines(combined_ignored);
     m_prefixFilterLinesCache  = split_lines(ui->pte_prefixFilter->toPlainText());
     m_stateFilterLinesCache   = split_lines(ui->pte_stateFilter->toPlainText());
     m_filterCacheValid = true;
@@ -14090,17 +14102,18 @@ bool MainWindow::callsignFiltered(DecodedText dt)
         return false;
     }
 
+    // Ignored stations filter: honor this even when global filtering is off.
+    if (m_ignoredStationsCache.contains(dxCall)
+        || m_ignoredStationsCache.contains(Radio::base_callsign(dxCall))) {
+        if (m_zdebug) log(QString("callsignFiltered: Ignored station: %1").arg(dxCall));
+        return true;
+    }
+
     if (!ui->cb_filtering->isChecked()) return false;
 
     // LOTW only filter
     if ( ui->cb_f_LOTW->isChecked() && !m_config.lotw_users ().user (dxCall)) {
         if (m_zdebug) log("callsignFiltered: User not in LOTW");
-        return true;
-    }
-
-    // Ignored stations filter
-    if (m_ignoredStationsCache.contains(dxCall)) {
-        if (m_zdebug) log("callsignFiltered: Station is in the ignore list");
         return true;
     }
 

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -14000,6 +14000,7 @@ void MainWindow::on_btn_addToIgnore_clicked( ) {
 
 void MainWindow::on_btn_clearIgnore_clicked( ) {
     ui->pte_IgnoredStations->clear();
+    ui->pte_IgnoredStations->appendPlainText(m_config.permIgnoreList());
     m_ignoreListReset = QDateTime::currentDateTime();
     m_filterCacheValid = false;
 }

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -2692,6 +2692,7 @@ void MainWindow::on_actionSettings_triggered()               //Setup Dialog
   auto my_grid = m_config.my_grid ();
   SpecOp nContest0=m_specOp;
   auto psk_on = m_config.spot_to_psk_reporter ();
+  auto perm_ignore_list = m_config.permIgnoreList ();
   inSettings = true;
   if (QDialog::Accepted == m_config.exec ()) {
     checkMSK144ContestType();
@@ -2703,6 +2704,9 @@ void MainWindow::on_actionSettings_triggered()               //Setup Dialog
     }
     if (m_config.my_callsign () != callsign || m_config.my_grid () != my_grid) {
       statusUpdate ();
+    }
+    if (m_config.permIgnoreList () != perm_ignore_list) {
+      invalidateFilterCache ();
     }
     on_dxGridEntry_textChanged (m_hisGrid); // recalculate distances in case of units change
     enable_DXCC_entity (m_config.DXCC ());  // sets text window proportions and (re)inits the logbook
@@ -6231,6 +6235,7 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
       return;
     }
 
+    if (!m_filterCacheValid) rebuildFilterCache();
     if (m_ignoredStationsCache.contains(hiscall)
         || m_ignoredStationsCache.contains(Radio::base_callsign(hiscall))) {
       return;


### PR DESCRIPTION
the ignore-list check now runs before the general filtering short-circuit, so ignored stations are blocked even when global filtering is off. also combined_ignored += m_config.permIgnoreList();